### PR TITLE
[MMCA-3612] - BugFix External view of standing authority following the introduction of an XI EORI (DDAs, GGAs, cash account) - find account you have authority to use - using account id(Frontend changes 1)

### DIFF
--- a/app/controllers/AuthorizedToViewController.scala
+++ b/app/controllers/AuthorizedToViewController.scala
@@ -242,7 +242,7 @@ class AuthorizedToViewController @Inject()(authenticate: IdentifierAction,
                                            xiAuthorities: SearchedAuthorities): SearchedAuthorities = {
     val listOfEligibleAuthorities = List(gbAuthorities, xiAuthorities).filter(sAuth => !getDisplayLink(sAuth))
 
-    if(listOfEligibleAuthorities.isEmpty) gbAuthorities else listOfEligibleAuthorities.head
+    if (listOfEligibleAuthorities.isEmpty) gbAuthorities else listOfEligibleAuthorities.head
   }
 
   private def getCsvFile(eori: String)(implicit req: AuthenticatedRequest[_]): Future[Seq[StandingAuthorityFile]] = {

--- a/app/controllers/AuthorizedToViewController.scala
+++ b/app/controllers/AuthorizedToViewController.scala
@@ -234,11 +234,16 @@ class AuthorizedToViewController @Inject()(authenticate: IdentifierAction,
 
   /**
    * Selects the SearchedAuthorities (out of GB and XI authorities) which has permission to show the balance.
+   * Selects gbAuthorities when both authorities have no balance
+   *
    * It is used only when search string is a valid account number
    */
   private def finalSearchAuthoritiesToShow(gbAuthorities: SearchedAuthorities,
-                                           xiAuthorities: SearchedAuthorities): SearchedAuthorities =
-    List(gbAuthorities, xiAuthorities).filter(sAuth => !getDisplayLink(sAuth)).head
+                                           xiAuthorities: SearchedAuthorities): SearchedAuthorities = {
+    val listOfEligibleAuthorities = List(gbAuthorities, xiAuthorities).filter(sAuth => !getDisplayLink(sAuth))
+
+    if(listOfEligibleAuthorities.isEmpty) gbAuthorities else listOfEligibleAuthorities.head
+  }
 
   private def getCsvFile(eori: String)(implicit req: AuthenticatedRequest[_]): Future[Seq[StandingAuthorityFile]] = {
     sdesConnector.getAuthoritiesCsvFiles(eori)


### PR DESCRIPTION
Description - Bugfix has been done by addressing the scenario where both the SearchAuthorities have no balance