### PR TITLE
[MMCA-4400] - Accessing bookmarked the page without deliverable email address - '/customs/payment-records/authorized-to-view

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,4 @@ yarn-debug.log
 yarn-error.log
 .metals/
 .vscode/
+.DS_Store

--- a/app/config/AppConfig.scala
+++ b/app/config/AppConfig.scala
@@ -27,6 +27,11 @@ class AppConfig @Inject()(val config: Configuration, val environment: Environmen
 
   lazy val appName: String = config.get[String]("appName")
 
+  lazy val emailFrontendService: String = s"${servicesConfig.baseUrl("customs-email-frontend")}${
+    config.get[String](
+      "microservice.services.customs-email-frontend.context")
+  }"
+
   lazy val timeout: Int = config.get[Int]("timeout.timeout")
   lazy val countdown: Int = config.get[Int]("timeout.countdown")
 
@@ -60,7 +65,7 @@ class AppConfig @Inject()(val config: Configuration, val environment: Environmen
   lazy val cashAccountUrl: String = config.get[String]("microservice.services.customs-cash-account-frontend.url")
   lazy val manageAuthoritiesFrontendUrl: String = config.get[String]("microservice.services.customs-manage-authorities-frontend.url")
   lazy val guaranteeAccountUrl: String = config.get[String]("microservice.services.customs-guarantee-account-frontend.url")
-  lazy val emailFrontendUrl: String = config.get[String]("microservice.services.customs-email-frontend.url")
+  lazy val emailFrontendUrl: String = s"$emailFrontendService/service/customs-finance"
   lazy val documentsUrl: String = config.get[String]("microservice.services.customs-financials-documents-frontend.url")
   lazy val importVATAccountUrl: String = s"$documentsUrl/import-vat"
   lazy val postponedVATAccountUrl: String = s"$documentsUrl/postponed-vat?location=CDS"

--- a/app/controllers/AuthorizedToViewController.scala
+++ b/app/controllers/AuthorizedToViewController.scala
@@ -16,7 +16,7 @@
 
 package controllers
 
-import actionbuilders.{AuthenticatedRequest, IdentifierAction}
+import actionbuilders.{AuthenticatedRequest, EmailAction, IdentifierAction}
 import config.{AppConfig, ErrorHandler}
 import connectors.{CustomsFinancialsApiConnector, SdesConnector}
 import domain.FileRole.StandingAuthority
@@ -43,19 +43,20 @@ class AuthorizedToViewController @Inject()(authenticate: IdentifierAction,
                                            val sdesConnector: SdesConnector,
                                            errorHandler: ErrorHandler,
                                            dataStoreService: DataStoreService,
+                                           verifyEmail: EmailAction,
                                            financialsApiConnector: CustomsFinancialsApiConnector,
                                            implicit val mcc: MessagesControllerComponents,
                                            authorisedToViewSearch: authorised_to_view_search,
                                            authorisedToViewSearchResult: authorised_to_view_search_result,
                                            authorisedToViewSearchNoResult: authorised_to_view_search_no_result,
                                            eoriNumberFormProvider: EoriNumberFormProvider)(
-                                           implicit val appConfig: AppConfig, ec: ExecutionContext)
+                                            implicit val appConfig: AppConfig, ec: ExecutionContext)
   extends FrontendController(mcc) with I18nSupport {
 
   val log: LoggerLike = Logger(this.getClass)
   val form: Form[String] = eoriNumberFormProvider()
 
-  def onPageLoad(): Action[AnyContent] = authenticate async { implicit req =>
+  def onPageLoad(): Action[AnyContent] = authenticate andThen verifyEmail async { implicit req =>
     financialsApiConnector.deleteNotification(req.user.eori, StandingAuthority)
 
     for {

--- a/app/controllers/EmailController.scala
+++ b/app/controllers/EmailController.scala
@@ -38,16 +38,13 @@ class EmailController @Inject()(authenticate: IdentifierAction,
 
   val log: LoggerLike = Logger(this.getClass)
 
-  def showUnverified():Action[AnyContent] = authenticate async { implicit request =>
-
-    financialsApiConnector.isEmailUnverified.map {
-      case a => Ok(verifyEmailView(appConfig.emailFrontendUrl, a))
-    }
+  def showUnverified(): Action[AnyContent] = authenticate async { implicit request =>
+    financialsApiConnector.isEmailUnverified.map(email => Ok(verifyEmailView(appConfig.emailFrontendUrl, email)))
   }
 
-  def showUndeliverable():Action[AnyContent] = authenticate async { implicit request =>
-    financialsApiConnector.getEmailaddress.map {
-      case a => Ok(undeliverableEmail(appConfig.emailFrontendUrl, a.verifiedEmail.get)(request, request.messages , appConfig))
-    }
+  def showUndeliverable(): Action[AnyContent] = authenticate async { implicit request =>
+    financialsApiConnector.getEmailaddress.map(
+      verifiedEmailRes => Ok(undeliverableEmail(appConfig.emailFrontendUrl,
+        verifiedEmailRes.verifiedEmail)(request, request.messages, appConfig)))
   }
 }

--- a/app/views/email/undeliverable_email.scala.html
+++ b/app/views/email/undeliverable_email.scala.html
@@ -26,14 +26,18 @@
         button: button,
         layout: Layout
 )
-@(nextPage: String, email: String)(implicit request: Request[_], messages: Messages, appConfig: AppConfig)
+@(
+        nextPage: String,
+        emailAddress: Option[String] = None
+)(implicit request: Request[_], messages: Messages, appConfig: AppConfig)
 
 @layout(pageTitle = Some(messages("cf.undeliverable.email.title"))) {
 
     @h1(msg = "cf.undeliverable.email.heading", classes = "govuk-heading-xl govuk-!-margin-bottom-4")
 
     @p("cf.undeliverable.email.p1")
-    @p(messages("cf.undeliverable.email.p2", email))
+
+    @emailAddress.map(mailId => p(messages("cf.undeliverable.email.p2", mailId)))
 
     @h2(msg = "cf.undeliverable.email.verify.heading", classes = "govuk-heading-m govuk-!-margin-bottom-4")
 

--- a/app/views/email/undeliverable_email.scala.html
+++ b/app/views/email/undeliverable_email.scala.html
@@ -49,6 +49,4 @@
     @p("cf.undeliverable.email.change.text.p2")
 
     <p class="govuk-body">@button("cf.undeliverable.email.link-text", Some(nextPage))</p>
-
 }
-

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -116,7 +116,10 @@ microservice {
     }
 
     customs-email-frontend {
-      url = "/manage-email-cds/service/customs-finance"
+      protocol = http
+      host = localhost
+      port = 9898
+      context = "/manage-email-cds"
     }
 
     customs-financials-secure-messaging-frontend {

--- a/test/config/AppConfigSpec.scala
+++ b/test/config/AppConfigSpec.scala
@@ -47,6 +47,18 @@ class AppConfigSpec extends SpecBase {
         "https://www.tax.service.gov.uk/customs-enrolment-services/cds/subscribe"
     }
   }
+
+  "emailFrontendService" should {
+    "return the correct service address with context" in new Setup {
+      appConfig.emailFrontendService shouldBe "http://localhost:9898/manage-email-cds"
+    }
+  }
+
+  "emailFrontendUrl" should {
+    "return the correct url" in new Setup {
+      appConfig.emailFrontendUrl shouldBe "http://localhost:9898/manage-email-cds/service/customs-finance"
+    }
+  }
   trait Setup {
     val app: Application = application().build()
     val appConfig: AppConfig = app.injector.instanceOf[AppConfig]

--- a/test/controllers/AuthorizedToViewControllerSpec.scala
+++ b/test/controllers/AuthorizedToViewControllerSpec.scala
@@ -49,9 +49,11 @@ class AuthorizedToViewControllerSpec extends SpecBase {
 
     "show the search EORI view when the feature flag is enabled" in new Setup {
       when(mockSdesConnector.getAuthoritiesCsvFiles(any)(any)).thenReturn(Future.successful(Seq.empty))
+
       val newApp: Application = application().overrides(
         inject.bind[SdesConnector].toInstance(mockSdesConnector)
       ).configure("features.new-agent-view-enabled" -> true).build()
+
       running(newApp) {
         val request = fakeRequest(GET, routes.AuthorizedToViewController.onPageLoad().url)
         val result = route(newApp, request).value
@@ -154,6 +156,7 @@ class AuthorizedToViewControllerSpec extends SpecBase {
 
   "The Authorized to View download CSV page" should {
     "return OK" in new Setup {
+
       when(mockDataStoreService.getEmail(any)(any)).thenReturn(Future.successful(Right(Email(emailId))))
 
       running(app) {
@@ -165,9 +168,11 @@ class AuthorizedToViewControllerSpec extends SpecBase {
 
     "download authorities csv page when requests all accounts" in new Setup {
       when(mockSdesConnector.getAuthoritiesCsvFiles(any)(any)).thenReturn(Future.successful(Seq.empty))
+
       val newApp: Application = application().overrides(
         inject.bind[SdesConnector].toInstance(mockSdesConnector)
       ).configure("microservice.services.sdes.context" -> true).build()
+
       running(newApp) {
         val request = fakeRequest(GET, routes.AuthorizedToViewController.onPageLoad().url)
         val result = route(newApp, request).value
@@ -276,8 +281,10 @@ class AuthorizedToViewControllerSpec extends SpecBase {
         AuthorisedCashAccount(Account("1234", "GeneralGuarantee", "GB000000000000"), None)
 
       when(mockApiService.searchAuthorities(any, any)(any))
-        .thenReturn(Future.successful(Right(SearchedAuthorities("3", Seq(guaranteeAccount, dutyDefermentAccount, cashAccount)))))
-        .andThenAnswer(Future.successful(Right(SearchedAuthorities("3", Seq(guaranteeAccount, dutyDefermentAccount, cashAccount)))))
+        .thenReturn(Future.successful(Right(SearchedAuthorities("3",
+          Seq(guaranteeAccount, dutyDefermentAccount, cashAccount)))))
+        .andThenAnswer(Future.successful(Right(SearchedAuthorities("3",
+          Seq(guaranteeAccount, dutyDefermentAccount, cashAccount)))))
 
       when(mockDataStoreService.getCompanyName(any)(any))
         .thenReturn(Future.successful(Some("Company name")))
@@ -285,9 +292,11 @@ class AuthorizedToViewControllerSpec extends SpecBase {
       when(mockDataStoreService.getXiEori(any)(any)).thenReturn(Future.successful(Option("XI123456789")))
 
       running(app) {
-        val request = fakeRequest(POST, routes.AuthorizedToViewController.onSubmit().url).withFormUrlEncodedBody("value" -> "GB123456789012")
+        val request = fakeRequest(POST, routes.AuthorizedToViewController.onSubmit().url).withFormUrlEncodedBody(
+          "value" -> "GB123456789012")
         val result = route(app, request).value
         val html = Jsoup.parse(contentAsString(result))
+
         status(result) shouldBe OK
         html.text().contains("Search results for GB123456789012") shouldBe true
       }
@@ -417,7 +426,9 @@ class AuthorizedToViewControllerSpec extends SpecBase {
     "return BAD_REQUEST if an invalid payload sent" in new Setup {
       when(mockSdesConnector.getAuthoritiesCsvFiles(any)(any)).thenReturn(Future.successful(Seq.empty))
       running(app) {
-        val request = fakeRequest(POST, routes.AuthorizedToViewController.onSubmit().url).withFormUrlEncodedBody("value" -> "ERROR")
+        val request = fakeRequest(POST, routes.AuthorizedToViewController.onSubmit().url).withFormUrlEncodedBody(
+          "value" -> "ERROR")
+
         val result = route(app, request).value
         status(result) shouldBe BAD_REQUEST
       }
@@ -434,6 +445,7 @@ class AuthorizedToViewControllerSpec extends SpecBase {
 
         val result = route(app, request).value
         val html = Jsoup.parse(contentAsString(result))
+
         status(result) shouldBe BAD_REQUEST
 
         html.getElementById("gb-csv-authority-link").html() mustBe
@@ -459,6 +471,7 @@ class AuthorizedToViewControllerSpec extends SpecBase {
 
         val result = route(app, request).value
         val html = Jsoup.parse(contentAsString(result))
+
         status(result) shouldBe BAD_REQUEST
 
         html.getElementById("gb-csv-authority-link").html() mustBe
@@ -484,6 +497,7 @@ class AuthorizedToViewControllerSpec extends SpecBase {
 
         val result = route(app, request).value
         val html = Jsoup.parse(contentAsString(result))
+
         status(result) shouldBe BAD_REQUEST
 
         html.text().contains(messages(app)("cf.search.authorities.error.register-xi-eori"))
@@ -533,6 +547,7 @@ class AuthorizedToViewControllerSpec extends SpecBase {
 
         val result = route(app, request).value
         val html = Jsoup.parse(contentAsString(result))
+
         status(result) shouldBe BAD_REQUEST
 
         html.getElementById("gb-csv-authority-link").html() mustBe
@@ -556,6 +571,7 @@ class AuthorizedToViewControllerSpec extends SpecBase {
 
         val result = route(app, request).value
         val html = Jsoup.parse(contentAsString(result))
+
         status(result) shouldBe BAD_REQUEST
 
         html.getElementById("gb-csv-authority-link").html() mustBe
@@ -580,6 +596,7 @@ class AuthorizedToViewControllerSpec extends SpecBase {
 
         val result = route(app, request).value
         val html = Jsoup.parse(contentAsString(result))
+
         status(result) shouldBe BAD_REQUEST
         html.text().contains("You cannot search your own account number") shouldBe true
       }
@@ -600,6 +617,7 @@ class AuthorizedToViewControllerSpec extends SpecBase {
 
         val result = route(app, request).value
         val html = Jsoup.parse(contentAsString(result))
+
         status(result) shouldBe BAD_REQUEST
         html.text().contains("You cannot search your own account number") shouldBe true
       }
@@ -615,6 +633,7 @@ class AuthorizedToViewControllerSpec extends SpecBase {
         val request = fakeRequest(GET, routes.AuthorizedToViewController.onPageLoad().url)
         val result = route(app, request).value
         val html = Jsoup.parse(contentAsString(result))
+
         html.containsLinkWithText("/customs/payment-records", "link-back")
       }
     }
@@ -627,6 +646,7 @@ class AuthorizedToViewControllerSpec extends SpecBase {
         val request = fakeRequest(GET, routes.AuthorizedToViewController.onPageLoad().url)
         val result = route(app, request).value
         val html = Jsoup.parse(contentAsString(result))
+
         html.getElementById("h1") must not be emptyString
       }
     }

--- a/test/views/email/UndeliverableEmailSpec.scala
+++ b/test/views/email/UndeliverableEmailSpec.scala
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package views.email
+
+import config.AppConfig
+import org.jsoup.Jsoup
+import org.jsoup.nodes.Document
+import org.scalatest.matchers.must.Matchers.convertToAnyMustWrapper
+import play.api.Application
+import play.api.i18n.Messages
+import play.api.mvc.AnyContentAsEmpty
+import play.api.test.FakeRequest
+import utils.SpecBase
+import views.html.email.undeliverable_email
+
+class UndeliverableEmailSpec extends SpecBase {
+
+  "view" should {
+    "display correct guidance and text" in new Setup {
+
+      view.title() mustBe
+        s"${messages(app)("cf.undeliverable.email.title")} - ${messages(app)("service.name")} - GOV.UK"
+
+      view.getElementsByTag("h1").text() mustBe messages(app)("cf.undeliverable.email.heading")
+
+      view.text().contains(messages(app)("cf.undeliverable.email.p1")) mustBe true
+      view.html.contains(messages(app)("cf.undeliverable.email.p2", email))
+
+      view.text().contains(messages(app)("cf.undeliverable.email.verify.heading")) mustBe true
+      view.text().contains(messages(app)("cf.undeliverable.email.verify.text.p1")) mustBe true
+      view.text().contains(messages(app)("cf.undeliverable.email.change.heading")) mustBe true
+
+      view.text().contains(messages(app)("cf.undeliverable.email.change.text.p1")) mustBe true
+      view.text().contains(messages(app)("cf.undeliverable.email.change.text.p2")) mustBe true
+
+      view.text().contains(messages(app)("cf.undeliverable.email.link-text")) mustBe true
+
+      view.toString should include(nextPageUrl)
+      view.text().contains(email.get) mustBe true
+    }
+
+    "not display the email paragraph if there is no email" in new Setup {
+      viewWithNoEmail.text().contains(email.get) mustBe false
+    }
+  }
+
+  trait Setup {
+    val app: Application = application().build()
+    val nextPageUrl = "test_url"
+    val email: Option[String] = Some("test@test.com")
+
+    implicit val appConfig: AppConfig = app.injector.instanceOf[AppConfig]
+    implicit val msg: Messages = messages(app)
+    implicit val request: FakeRequest[AnyContentAsEmpty.type] = FakeRequest("GET", "/some/resource/path")
+
+    val view: Document = Jsoup.parse(
+      app.injector.instanceOf[undeliverable_email].apply(nextPageUrl, email).body)
+
+    val viewWithNoEmail: Document = Jsoup.parse(
+      app.injector.instanceOf[undeliverable_email].apply(nextPageUrl).body)
+
+  }
+}


### PR DESCRIPTION
Description - Code changes to redirect user to email undeliverable  page if the EORI has undeliverable email in the DB

Below have been done as part of this PR

- new test class for undeliverable view
- add new tests and updated existing tests for the AuthorizedToViewController
- add new config for customs-email-frontend
- relevant code changes
- minor refactoring  