### PR TITLE
[MMCA- 4608] - Implement ACC29 call to retrieve manage authorities details (Fire-and-Forget backend changes)

### DIFF
--- a/app/config/AppConfig.scala
+++ b/app/config/AppConfig.scala
@@ -58,6 +58,11 @@ class AppConfig @Inject()(val config: Configuration, servicesConfig: ServicesCon
   lazy val manageAuthoritiesFrontendUrl: String =
     config.get[String]("microservice.services.customs-manage-authorities-frontend.url")
 
+  lazy val manageAuthoritiesServiceUrl = s"${servicesConfig.baseUrl("customs-manage-authorities-frontend")}${
+    config.get[String](
+      "microservice.services.customs-manage-authorities-frontend.context")
+  }"
+
   lazy val guaranteeAccountUrl: String =
     config.get[String]("microservice.services.customs-guarantee-account-frontend.url")
 

--- a/app/connectors/CustomsFinancialsSessionCacheConnector.scala
+++ b/app/connectors/CustomsFinancialsSessionCacheConnector.scala
@@ -35,7 +35,6 @@ object AccountLinksRequest {
   implicit val format: OFormat[AccountLinksRequest] = Json.format[AccountLinksRequest]
 }
 
-
 class CustomsFinancialsSessionCacheConnector @Inject()(httpClient: HttpClient,
                                                        appConfig: AppConfig,
                                                        metricsReporter: MetricsReporterService)

--- a/app/connectors/CustomsManageAuthoritiesConnector.scala
+++ b/app/connectors/CustomsManageAuthoritiesConnector.scala
@@ -20,20 +20,26 @@ import config.AppConfig
 import domain.EORI
 import play.api.Logging
 import play.api.http.Status.{INTERNAL_SERVER_ERROR, NO_CONTENT, OK}
-import play.api.mvc.Results
-import play.api.mvc.Results.{InternalServerError, Ok}
+import play.api.mvc.Results.{InternalServerError, Ok, ServiceUnavailable}
+import play.api.mvc.{RequestHeader, Results}
 import services.MetricsReporterService
+import uk.gov.hmrc.http.HttpReads.Implicits._
 import uk.gov.hmrc.http.{HeaderCarrier, HttpClient, HttpResponse}
+import uk.gov.hmrc.play.partials.HeaderCarrierForPartialsConverter
 
 import javax.inject.Inject
 import scala.concurrent.{ExecutionContext, Future}
 
 class CustomsManageAuthoritiesConnector @Inject()(httpClient: HttpClient,
                                                   appConfig: AppConfig,
-                                                  metricsReporter: MetricsReporterService)
+                                                  metricsReporter: MetricsReporterService,
+                                                  headerCarrierForPartialsConverter: HeaderCarrierForPartialsConverter)
                                                  (implicit executionContext: ExecutionContext) extends Logging {
 
-  def fetchAndSaveAccountAuthoritiesInCache(eori: EORI)(implicit hc: HeaderCarrier): Future[Results.Status] = {
+  def fetchAndSaveAccountAuthoritiesInCache(eori: EORI)(implicit request: RequestHeader): Future[Results.Status] = {
+
+    implicit val hc: HeaderCarrier = headerCarrierForPartialsConverter.fromRequestWithEncryptedCookie(request)
+
     val endPointUrl = s"${appConfig.manageAuthoritiesServiceUrl}/account-authorities/fetch-authorities/$eori"
 
     httpClient.GET[HttpResponse](endPointUrl).map {
@@ -50,6 +56,10 @@ class CustomsManageAuthoritiesConnector @Inject()(httpClient: HttpClient,
           case INTERNAL_SERVER_ERROR =>
             logger.warn(s"Error occurred while saving the authorities' details in cache for $eori")
             Future.successful(InternalServerError)
+
+          case _ =>
+            logger.warn(s"Error occurred while saving the authorities' details in cache for $eori")
+            Future.successful(ServiceUnavailable)
         }
     }.recover {
       case _ =>

--- a/app/connectors/CustomsManageAuthoritiesConnector.scala
+++ b/app/connectors/CustomsManageAuthoritiesConnector.scala
@@ -22,7 +22,6 @@ import play.api.Logging
 import play.api.http.Status.{INTERNAL_SERVER_ERROR, NO_CONTENT, OK}
 import play.api.mvc.Results.{InternalServerError, Ok, ServiceUnavailable}
 import play.api.mvc.{RequestHeader, Results}
-import services.MetricsReporterService
 import uk.gov.hmrc.http.HttpReads.Implicits._
 import uk.gov.hmrc.http.{HeaderCarrier, HttpClient, HttpResponse}
 import uk.gov.hmrc.play.partials.HeaderCarrierForPartialsConverter
@@ -32,7 +31,6 @@ import scala.concurrent.{ExecutionContext, Future}
 
 class CustomsManageAuthoritiesConnector @Inject()(httpClient: HttpClient,
                                                   appConfig: AppConfig,
-                                                  metricsReporter: MetricsReporterService,
                                                   headerCarrierForPartialsConverter: HeaderCarrierForPartialsConverter)
                                                  (implicit executionContext: ExecutionContext) extends Logging {
 

--- a/app/connectors/CustomsManageAuthoritiesConnector.scala
+++ b/app/connectors/CustomsManageAuthoritiesConnector.scala
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package connectors
+
+import config.AppConfig
+import domain.EORI
+import play.api.Logging
+import play.api.http.Status.{INTERNAL_SERVER_ERROR, NO_CONTENT, OK}
+import play.api.mvc.Results
+import play.api.mvc.Results.{InternalServerError, Ok}
+import services.MetricsReporterService
+import uk.gov.hmrc.http.{HeaderCarrier, HttpClient, HttpResponse}
+
+import javax.inject.Inject
+import scala.concurrent.{ExecutionContext, Future}
+
+class CustomsManageAuthoritiesConnector @Inject()(httpClient: HttpClient,
+                                                  appConfig: AppConfig,
+                                                  metricsReporter: MetricsReporterService)
+                                                 (implicit executionContext: ExecutionContext) extends Logging {
+
+  def fetchAndSaveAccountAuthoritiesInCache(eori: EORI)(implicit hc: HeaderCarrier): Future[Results.Status] = {
+    val endPointUrl = s"${appConfig.manageAuthoritiesServiceUrl}/account-authorities/fetch-authorities/$eori"
+
+    httpClient.GET[HttpResponse](endPointUrl).map {
+      res =>
+        res.status match {
+          case OK =>
+            logger.info(s"Authorities' details have been successfully saved in the cache for $eori")
+            Future.successful(Ok)
+
+          case NO_CONTENT =>
+            logger.info(s"No data found for $eori")
+            Future.successful(Ok)
+
+          case INTERNAL_SERVER_ERROR =>
+            logger.warn(s"Error occurred while saving the authorities' details in cache for $eori")
+            Future.successful(InternalServerError)
+        }
+    }.recover {
+      case _ =>
+        logger.warn(s"Error occurred while saving the authorities' details in cache for $eori")
+        Future.successful(InternalServerError)
+    }.flatten
+
+  }
+}

--- a/app/controllers/CustomsFinancialsHomeController.scala
+++ b/app/controllers/CustomsFinancialsHomeController.scala
@@ -18,7 +18,7 @@ package controllers
 
 import actionbuilders.{AuthenticatedRequest, EmailAction, IdentifierAction}
 import config.AppConfig
-import connectors.{CustomsFinancialsSessionCacheConnector, SecureMessageConnector}
+import connectors.{CustomsFinancialsSessionCacheConnector, CustomsManageAuthoritiesConnector, SecureMessageConnector}
 import domain.FileRole.{DutyDefermentStatement, PostponedVATAmendedStatement, StandingAuthority}
 import domain._
 import play.api.i18n.I18nSupport
@@ -50,6 +50,7 @@ class CustomsFinancialsHomeController @Inject()(authenticate: IdentifierAction,
                                                 accountNotAvailable: account_not_available,
                                                 sessionCacheConnector: CustomsFinancialsSessionCacheConnector,
                                                 secureMessageConnector: SecureMessageConnector,
+                                                customsManageAuthConnector:CustomsManageAuthoritiesConnector,
                                                 implicit val mcc: MessagesControllerComponents)
                                                (implicit val appConfig: AppConfig, ec: ExecutionContext)
   extends FrontendController(mcc) with I18nSupport {
@@ -65,6 +66,7 @@ class CustomsFinancialsHomeController @Inject()(authenticate: IdentifierAction,
         maybeBannerPartial <- secureMessageConnector.getMessageCountBanner(returnToUrl)
         xiEori <- dataStoreService.getXiEori(eori)
         allAccounts <- getAllAccounts(eori, xiEori)
+        _ <- customsManageAuthConnector.fetchAndSaveAccountAuthoritiesInCache(eori)
         page <- if (allAccounts.nonEmpty) {
           pageWithAccounts(eori, xiEori, allAccounts, maybeBannerPartial)
         } else {

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -88,6 +88,7 @@ microservice {
       url = "http://localhost:9000/customs/manage-authorities"
       host = localhost
       port = 9000
+      protocol = http
       context = "/customs/manage-authorities"
     }
 

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -86,6 +86,9 @@ microservice {
 
     customs-manage-authorities-frontend {
       url = "http://localhost:9000/customs/manage-authorities"
+      host = localhost
+      port = 9000
+      context = "/customs/manage-authorities"
     }
 
     customs-duty-deferment-frontend {

--- a/test/config/AppConfigSpec.scala
+++ b/test/config/AppConfigSpec.scala
@@ -60,6 +60,12 @@ class AppConfigSpec extends SpecBase {
     }
   }
 
+  "manageAuthoritiesServiceUrl" should {
+    "return the correct service url" in new Setup {
+      appConfig.manageAuthoritiesServiceUrl shouldBe "http://localhost:9000/customs/manage-authorities"
+    }
+  }
+
   trait Setup {
     val app: Application = application().build()
     val appConfig: AppConfig = app.injector.instanceOf[AppConfig]

--- a/test/connectors/CustomsManageAuthoritiesConnectorSpec.scala
+++ b/test/connectors/CustomsManageAuthoritiesConnectorSpec.scala
@@ -1,0 +1,105 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package connectors
+
+import config.AppConfig
+import org.mockito.ArgumentMatchers.any
+import org.scalatest.concurrent.ScalaFutures
+import org.scalatest.matchers.must.Matchers.convertToAnyMustWrapper
+import play.api.http.Status.{INTERNAL_SERVER_ERROR, NO_CONTENT, OK}
+import play.api.test.Helpers.{running, status}
+import play.api.test.{DefaultAwaitTimeout, FutureAwaits}
+import play.api.{Application, inject}
+import uk.gov.hmrc.http.{HeaderCarrier, HttpClient, HttpResponse, UpstreamErrorResponse}
+import utils.SpecBase
+import utils.TestData.TEST_EORI
+
+import scala.concurrent.Future
+
+class CustomsManageAuthoritiesConnectorSpec extends SpecBase
+  with ScalaFutures
+  with FutureAwaits
+  with DefaultAwaitTimeout {
+
+  "fetchAndSaveAccountAuthoritiesInCache" should {
+
+    "return the correct result" when {
+
+      "API call to fetch authorities is successful" in new Setup {
+        running(app) {
+          val connector = app.injector.instanceOf[CustomsManageAuthoritiesConnector]
+
+          when[Future[HttpResponse]](mockHttpClient.GET(any, any, any)(any, any, any))
+            .thenReturn(Future.successful(HttpResponse.apply(OK, emptyString)))
+
+          val result = connector.fetchAndSaveAccountAuthoritiesInCache(TEST_EORI)
+          status(result) mustBe OK
+        }
+      }
+
+      "API call to fetch authorities returns NO_CONTENT" in new Setup {
+        running(app) {
+          val connector = app.injector.instanceOf[CustomsManageAuthoritiesConnector]
+
+          when[Future[HttpResponse]](mockHttpClient.GET(any, any, any)(any, any, any))
+            .thenReturn(Future.successful(HttpResponse.apply(NO_CONTENT, emptyString)))
+
+          val result = connector.fetchAndSaveAccountAuthoritiesInCache(TEST_EORI)
+          status(result) mustBe OK
+        }
+      }
+
+      "API call to fetch authorities returns INTERNAL_SERVER_ERROR" in new Setup {
+        running(app) {
+          val connector = app.injector.instanceOf[CustomsManageAuthoritiesConnector]
+
+          when[Future[HttpResponse]](mockHttpClient.GET(any, any, any)(any, any, any))
+            .thenReturn(Future.successful(HttpResponse.apply(INTERNAL_SERVER_ERROR, emptyString)))
+
+          val result = connector.fetchAndSaveAccountAuthoritiesInCache(TEST_EORI)
+          status(result) mustBe INTERNAL_SERVER_ERROR
+        }
+      }
+
+      "API call to fetch authorities throws exception" in new Setup {
+        running(app) {
+          val connector = app.injector.instanceOf[CustomsManageAuthoritiesConnector]
+
+          when[Future[HttpResponse]](mockHttpClient.GET(any, any, any)(any, any, any))
+            .thenReturn(Future.failed(UpstreamErrorResponse("Internal Error", INTERNAL_SERVER_ERROR)))
+
+          val result = connector.fetchAndSaveAccountAuthoritiesInCache(TEST_EORI)
+          status(result) mustBe INTERNAL_SERVER_ERROR
+        }
+      }
+    }
+  }
+
+  trait Setup {
+    val mockAppConfig: AppConfig = mock[AppConfig]
+    val mockHttpClient: HttpClient = mock[HttpClient]
+    val endPointUrl =
+      s"http://localhost:9000/customs/manage-authorities/account-authorities/fetch-authorities/$TEST_EORI"
+
+    implicit val hc: HeaderCarrier = HeaderCarrier()
+
+    val app: Application = application().overrides(
+      inject.bind[AppConfig].toInstance(mockAppConfig),
+      inject.bind[HttpClient].toInstance(mockHttpClient)
+    ).build()
+  }
+}

--- a/test/connectors/CustomsManageAuthoritiesConnectorSpec.scala
+++ b/test/connectors/CustomsManageAuthoritiesConnectorSpec.scala
@@ -20,7 +20,7 @@ import config.AppConfig
 import org.mockito.ArgumentMatchers.any
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.matchers.must.Matchers.convertToAnyMustWrapper
-import play.api.http.Status.{INTERNAL_SERVER_ERROR, NO_CONTENT, OK}
+import play.api.http.Status.{INTERNAL_SERVER_ERROR, NO_CONTENT, OK, SERVICE_UNAVAILABLE}
 import play.api.test.Helpers.{running, status}
 import play.api.test.{DefaultAwaitTimeout, FutureAwaits}
 import play.api.{Application, inject}
@@ -46,7 +46,7 @@ class CustomsManageAuthoritiesConnectorSpec extends SpecBase
           when[Future[HttpResponse]](mockHttpClient.GET(any, any, any)(any, any, any))
             .thenReturn(Future.successful(HttpResponse.apply(OK, emptyString)))
 
-          val result = connector.fetchAndSaveAccountAuthoritiesInCache(TEST_EORI)
+          val result = connector.fetchAndSaveAccountAuthoritiesInCache(TEST_EORI)(fakeRequest())
           status(result) mustBe OK
         }
       }
@@ -58,7 +58,7 @@ class CustomsManageAuthoritiesConnectorSpec extends SpecBase
           when[Future[HttpResponse]](mockHttpClient.GET(any, any, any)(any, any, any))
             .thenReturn(Future.successful(HttpResponse.apply(NO_CONTENT, emptyString)))
 
-          val result = connector.fetchAndSaveAccountAuthoritiesInCache(TEST_EORI)
+          val result = connector.fetchAndSaveAccountAuthoritiesInCache(TEST_EORI)(fakeRequest())
           status(result) mustBe OK
         }
       }
@@ -70,8 +70,20 @@ class CustomsManageAuthoritiesConnectorSpec extends SpecBase
           when[Future[HttpResponse]](mockHttpClient.GET(any, any, any)(any, any, any))
             .thenReturn(Future.successful(HttpResponse.apply(INTERNAL_SERVER_ERROR, emptyString)))
 
-          val result = connector.fetchAndSaveAccountAuthoritiesInCache(TEST_EORI)
+          val result = connector.fetchAndSaveAccountAuthoritiesInCache(TEST_EORI)(fakeRequest())
           status(result) mustBe INTERNAL_SERVER_ERROR
+        }
+      }
+
+      "API call to fetch authorities returns SERVICE_UNAVAILABLE" in new Setup {
+        running(app) {
+          val connector = app.injector.instanceOf[CustomsManageAuthoritiesConnector]
+
+          when[Future[HttpResponse]](mockHttpClient.GET(any, any, any)(any, any, any))
+            .thenReturn(Future.successful(HttpResponse.apply(SERVICE_UNAVAILABLE, emptyString)))
+
+          val result = connector.fetchAndSaveAccountAuthoritiesInCache(TEST_EORI)(fakeRequest())
+          status(result) mustBe SERVICE_UNAVAILABLE
         }
       }
 
@@ -82,7 +94,7 @@ class CustomsManageAuthoritiesConnectorSpec extends SpecBase
           when[Future[HttpResponse]](mockHttpClient.GET(any, any, any)(any, any, any))
             .thenReturn(Future.failed(UpstreamErrorResponse("Internal Error", INTERNAL_SERVER_ERROR)))
 
-          val result = connector.fetchAndSaveAccountAuthoritiesInCache(TEST_EORI)
+          val result = connector.fetchAndSaveAccountAuthoritiesInCache(TEST_EORI)(fakeRequest())
           status(result) mustBe INTERNAL_SERVER_ERROR
         }
       }

--- a/test/controllers/HomeControllerSpec.scala
+++ b/test/controllers/HomeControllerSpec.scala
@@ -17,20 +17,17 @@
 package controllers
 
 import config.AppConfig
-import connectors.CustomsFinancialsSessionCacheConnector
-import domain.FileRole.{
-  C79Certificate, DutyDefermentStatement, PostponedVATAmendedStatement, PostponedVATStatement,
-  SecurityStatement, StandingAuthority
-}
-import domain.{
-  AccountStatusOpen, CDSAccount, CDSAccounts, CDSCashBalance, CashAccount, DefermentAccountAvailable,
-  DutyDefermentAccount, DutyDefermentBalance, GeneralGuaranteeAccount, GeneralGuaranteeBalance, XiEoriAddressInformation
-}
+import connectors.{CustomsFinancialsSessionCacheConnector, CustomsManageAuthoritiesConnector}
+import domain.FileRole.{C79Certificate, DutyDefermentStatement, PostponedVATAmendedStatement, PostponedVATStatement,
+  SecurityStatement, StandingAuthority}
+import domain.{AccountStatusOpen, CDSAccount, CDSAccounts, CDSCashBalance, CashAccount, DefermentAccountAvailable,
+  DutyDefermentAccount, DutyDefermentBalance, GeneralGuaranteeAccount, GeneralGuaranteeBalance, XiEoriAddressInformation}
 import org.jsoup.Jsoup
 import org.mockito.ArgumentMatchersSugar.{any, eqTo}
 import org.scalatest.matchers.must.Matchers.convertToAnyMustWrapper
 import play.api.http.Status
 import play.api.i18n.Messages
+import play.api.mvc.Results.Ok
 import play.api.{Application, inject}
 import play.api.test.Helpers
 import play.api.test.Helpers._
@@ -482,6 +479,7 @@ class HomeControllerSpec extends SpecBase {
     val mockNotificationService: NotificationService = mock[NotificationService]
     val mockDataStoreService: DataStoreService = mock[DataStoreService]
     val mockSessionCacheConnector: CustomsFinancialsSessionCacheConnector = mock[CustomsFinancialsSessionCacheConnector]
+    val mockManageAuthoritiesConnector: CustomsManageAuthoritiesConnector = mock[CustomsManageAuthoritiesConnector]
 
     when(mockNotificationService.fetchNotifications(eqTo(eoriNumber))(any)).thenReturn(Future.successful(List.empty))
     when(mockApiService.getAccounts(any)(any)).thenReturn(Future.successful(mockAccounts))
@@ -500,6 +498,8 @@ class HomeControllerSpec extends SpecBase {
       Future.successful(HttpResponse(Status.OK, emptyString)))
 
     when(mockDataStoreService.getXiEori(any)(any)).thenReturn(Future.successful(Some(xi.xiEori)))
+    when(mockManageAuthoritiesConnector.fetchAndSaveAccountAuthoritiesInCache(any)(any))
+      .thenReturn(Future.successful(Ok))
 
     val app: Application = application().overrides(
       inject.bind[CDSAccounts].toInstance(mockAccounts),

--- a/test/controllers/HomeControllerSpec.scala
+++ b/test/controllers/HomeControllerSpec.scala
@@ -519,7 +519,7 @@ class HomeControllerSpec extends SpecBase {
       inject.bind[NotificationService].toInstance(mockNotificationService),
       inject.bind[DataStoreService].toInstance(mockDataStoreService),
       inject.bind[CustomsFinancialsSessionCacheConnector].toInstance(mockSessionCacheConnector),
-      inject.bind[CustomsManageAuthoritiesConnector].toInstance(mockManageAuthoritiesConnector),
+      inject.bind[CustomsManageAuthoritiesConnector].toInstance(mockManageAuthoritiesConnector)
     ).build()
   }
 }

--- a/test/utils/TestData.scala
+++ b/test/utils/TestData.scala
@@ -104,4 +104,6 @@ object TestData {
   val LENGTH_8 = 8
   val LENGTH_11 = 11
   val LENGTH_27 = 27
+
+  val TEST_EORI = "GB12345678"
 }


### PR DESCRIPTION
Description - Code changes to fetch and save account authorities in the cache on Customs financials home page load

Below have been done as part of this PR

-  add new Connector to communicate with Manage authorities frontend
- add config for manage authorities frontend
- add tests and relevant code changes
- updated existing tests
- minor refactoring