### PR TITLE
[MMCA-4779_1]  - Bug fix to show the correct duty deferment account details for certain EORIs

### DIFF
--- a/app/domain/AccountResponse.scala
+++ b/app/domain/AccountResponse.scala
@@ -16,7 +16,7 @@
 
 package domain
 
-import play.api.libs.json.{Json, OWrites, Reads}
+import play.api.libs.json.{Json, Reads}
 
 case class AccountResponse(number: String,
                            `type`: String,

--- a/app/domain/AccountResponse.scala
+++ b/app/domain/AccountResponse.scala
@@ -16,7 +16,7 @@
 
 package domain
 
-import play.api.libs.json.{Json, Reads}
+import play.api.libs.json.{Json, OWrites, Reads}
 
 case class AccountResponse(number: String,
                            `type`: String,
@@ -24,7 +24,7 @@ case class AccountResponse(number: String,
                            accountStatus: Option[CDSAccountStatus],
                            accountStatusID: Option[CDSAccountStatusId],
                            viewBalanceIsGranted: Boolean,
-                           isleOfManFlag: Option[Boolean] = Some(false))
+                           isleOfManFlag: Option[Boolean] = None)
 
 object AccountResponse {
   implicit val reads: Reads[AccountResponse] = Json.reads[AccountResponse]

--- a/test/domain/AccountResponseSpec.scala
+++ b/test/domain/AccountResponseSpec.scala
@@ -25,7 +25,7 @@ class AccountResponseSpec extends SpecBase with MustMatchers {
   "reads" should {
 
     "create the object correctly" when {
-      
+
       "isleOfManFlag is absence in the json representation" in new Setup {
         Json.fromJson(Json.parse(accResResponseString)) mustBe JsSuccess(accResWithDefaultIOMFlag)
       }

--- a/test/domain/AccountResponseSpec.scala
+++ b/test/domain/AccountResponseSpec.scala
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package domain
+
+import utils.{MustMatchers, SpecBase}
+import play.api.libs.json.{JsObject, JsSuccess, Json}
+
+class AccountResponseSpec extends SpecBase with MustMatchers {
+
+  "reads" should {
+    "create the object correctly" in {
+      import AccountResponse.reads
+
+      val accRes = AccountResponse(number = "12345678",
+        `type` = "DutyDeferment",
+        owner = "test_eori",
+        accountStatus = Some(AccountStatusSuspended),
+        accountStatusID = Some(DirectDebitMandateCancelled),
+        viewBalanceIsGranted = true,
+        isleOfManFlag= None)
+
+      val accResResponseString =
+        """{
+          |"number":"12345678",
+          |"accountStatusID":4,
+          |"accountStatus":"suspended",
+          |"owner":"test_eori",
+          |"type":"DutyDeferment",
+          |"viewBalanceIsGranted":true
+          |}""".stripMargin
+
+      Json.fromJson(Json.parse(accResResponseString)) mustBe JsSuccess(accRes)
+    }
+  }
+}

--- a/test/domain/AccountResponseSpec.scala
+++ b/test/domain/AccountResponseSpec.scala
@@ -17,33 +17,61 @@
 package domain
 
 import utils.{MustMatchers, SpecBase}
-import play.api.libs.json.{JsObject, JsSuccess, Json}
+import play.api.libs.json.{JsSuccess, Json}
+import AccountResponse.reads
 
 class AccountResponseSpec extends SpecBase with MustMatchers {
 
   "reads" should {
-    "create the object correctly" in {
-      import AccountResponse.reads
 
-      val accRes = AccountResponse(number = "12345678",
-        `type` = "DutyDeferment",
-        owner = "test_eori",
-        accountStatus = Some(AccountStatusSuspended),
-        accountStatusID = Some(DirectDebitMandateCancelled),
-        viewBalanceIsGranted = true,
-        isleOfManFlag= None)
+    "create the object correctly" when {
+      
+      "isleOfManFlag is absence in the json representation" in new Setup {
+        Json.fromJson(Json.parse(accResResponseString)) mustBe JsSuccess(accResWithDefaultIOMFlag)
+      }
 
-      val accResResponseString =
-        """{
-          |"number":"12345678",
-          |"accountStatusID":4,
-          |"accountStatus":"suspended",
-          |"owner":"test_eori",
-          |"type":"DutyDeferment",
-          |"viewBalanceIsGranted":true
-          |}""".stripMargin
-
-      Json.fromJson(Json.parse(accResResponseString)) mustBe JsSuccess(accRes)
+      "isleOfManFlag value is present in the json representation" in new Setup {
+        Json.fromJson(Json.parse(accResResponseWithIOMValueString)) mustBe JsSuccess(accResWithIOMFlag)
+      }
     }
+  }
+
+  trait Setup {
+
+    val accResWithDefaultIOMFlag: AccountResponse = AccountResponse(number = "12345678",
+      `type` = "DutyDeferment",
+      owner = "test_eori",
+      accountStatus = Some(AccountStatusSuspended),
+      accountStatusID = Some(DirectDebitMandateCancelled),
+      viewBalanceIsGranted = true)
+
+    val accResWithIOMFlag: AccountResponse = AccountResponse(number = "12345678",
+      `type` = "DutyDeferment",
+      owner = "test_eori",
+      accountStatus = Some(AccountStatusSuspended),
+      accountStatusID = Some(DirectDebitMandateCancelled),
+      viewBalanceIsGranted = true,
+      isleOfManFlag = Some(true))
+
+    val accResResponseWithIOMValueString: String =
+      """{
+        |"number":"12345678",
+        |"accountStatusID":4,
+        |"accountStatus":"suspended",
+        |"owner":"test_eori",
+        |"type":"DutyDeferment",
+        |"viewBalanceIsGranted":true,
+        |"isleOfManFlag":true
+        |}""".stripMargin
+
+    val accResResponseString: String =
+      """{
+        |"number":"12345678",
+        |"accountStatusID":4,
+        |"accountStatus":"suspended",
+        |"owner":"test_eori",
+        |"type":"DutyDeferment",
+        |"viewBalanceIsGranted":true
+        |}""".stripMargin
   }
 }


### PR DESCRIPTION
Description - Scala 3 upgrade have changed how it reads the default optional values hence it was populating the object with  default value while reading the json. Object default value has been updated to have None

Below has been done as part of this PR

- Add test class for AccountResponse
- relevant code change