### PR TITLE
MMCA-4800 | Use customs-data-store routes for email retrieval on customs-financials-frontend

### DIFF
--- a/app/connectors/CustomsDataStoreConnector.scala
+++ b/app/connectors/CustomsDataStoreConnector.scala
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package connectors
+
+import config.AppConfig
+import uk.gov.hmrc.http.HttpReads.Implicits.*
+import uk.gov.hmrc.http.client.HttpClientV2
+import uk.gov.hmrc.http.{HeaderCarrier, StringContextOps}
+import domain.{EmailUnverifiedResponse, EmailVerifiedResponse}
+
+import javax.inject.Inject
+import scala.concurrent.{ExecutionContext, Future}
+
+class CustomsDataStoreConnector @Inject()(appConfig: AppConfig,
+                                          httpClient: HttpClientV2)(implicit ec: ExecutionContext) {
+
+  def isEmailVerified(implicit hc: HeaderCarrier): Future[EmailVerifiedResponse] = {
+    httpClient.get(url"${appConfig.customsDataStore}/subscriptions/subscriptionsdisplay")
+      .execute[EmailVerifiedResponse]
+      .flatMap {
+        response => Future.successful(response)
+      }
+  }
+
+  def getEmailAddress(implicit hc: HeaderCarrier): Future[EmailVerifiedResponse] = {
+    httpClient.get(url"${appConfig.customsDataStore}/subscriptions/email-display")
+      .execute[EmailVerifiedResponse]
+      .flatMap {
+        response => Future.successful(response)
+      }
+  }
+
+  def isEmailUnverified(implicit hc: HeaderCarrier): Future[Option[String]] = {
+    httpClient.get(url"${appConfig.customsDataStore}/subscriptions/unverified-email-display")
+      .execute[EmailUnverifiedResponse]
+      .flatMap {
+        res => Future.successful(res.unVerifiedEmail)
+      }
+  }
+}

--- a/app/connectors/CustomsFinancialsApiConnector.scala
+++ b/app/connectors/CustomsFinancialsApiConnector.scala
@@ -17,7 +17,7 @@
 package connectors
 
 import config.AppConfig
-import domain.{EmailUnverifiedResponse, EmailVerifiedResponse, FileRole}
+import domain.FileRole
 import play.mvc.Http.Status
 import services.MetricsReporterService
 import uk.gov.hmrc.http.HttpReads.Implicits.*
@@ -30,30 +30,6 @@ import scala.concurrent.{ExecutionContext, Future}
 class CustomsFinancialsApiConnector @Inject()(appConfig: AppConfig,
                                               httpClient: HttpClientV2,
                                               metricsReporter: MetricsReporterService)(implicit ec: ExecutionContext) {
-
-  def isEmailVerified(implicit hc: HeaderCarrier): Future[EmailVerifiedResponse] = {
-    httpClient.get(url"${appConfig.customsDataStore}/subscriptions/subscriptionsdisplay")
-      .execute[EmailVerifiedResponse]
-      .flatMap {
-        response => Future.successful(response)
-      }
-  }
-
-  def getEmailAddress(implicit hc: HeaderCarrier): Future[EmailVerifiedResponse] = {
-    httpClient.get(url"${appConfig.customsDataStore}/subscriptions/email-display")
-      .execute[EmailVerifiedResponse]
-      .flatMap {
-        response => Future.successful(response)
-      }
-  }
-
-  def isEmailUnverified(implicit hc: HeaderCarrier): Future[Option[String]] = {
-    httpClient.get(url"${appConfig.customsDataStore}/subscriptions/unverified-email-display")
-      .execute[EmailUnverifiedResponse]
-      .flatMap {
-        res => Future.successful(res.unVerifiedEmail)
-      }
-  }
 
   def deleteNotification(eori: String,
                          fileRole: FileRole)(implicit hc: HeaderCarrier): Future[Boolean] = {

--- a/app/connectors/CustomsFinancialsApiConnector.scala
+++ b/app/connectors/CustomsFinancialsApiConnector.scala
@@ -23,7 +23,6 @@ import services.MetricsReporterService
 import uk.gov.hmrc.http.HttpReads.Implicits.*
 import uk.gov.hmrc.http.client.HttpClientV2
 import uk.gov.hmrc.http.{HeaderCarrier, HttpResponse, StringContextOps}
-import play.api.libs.ws.JsonBodyWritables.writeableOf_JsValue
 
 import javax.inject.Inject
 import scala.concurrent.{ExecutionContext, Future}
@@ -33,15 +32,15 @@ class CustomsFinancialsApiConnector @Inject()(appConfig: AppConfig,
                                               metricsReporter: MetricsReporterService)(implicit ec: ExecutionContext) {
 
   def isEmailVerified(implicit hc: HeaderCarrier): Future[EmailVerifiedResponse] = {
-    httpClient.get(url"${appConfig.customsFinancialsApi}/subscriptions/subscriptionsdisplay")
+    httpClient.get(url"${appConfig.customsDataStore}/subscriptions/subscriptionsdisplay")
       .execute[EmailVerifiedResponse]
       .flatMap {
         response => Future.successful(response)
       }
   }
 
-  def getEmailaddress(implicit hc: HeaderCarrier): Future[EmailVerifiedResponse] = {
-    httpClient.get(url"${appConfig.customsFinancialsApi}/subscriptions/email-display")
+  def getEmailAddress(implicit hc: HeaderCarrier): Future[EmailVerifiedResponse] = {
+    httpClient.get(url"${appConfig.customsDataStore}/subscriptions/email-display")
       .execute[EmailVerifiedResponse]
       .flatMap {
         response => Future.successful(response)
@@ -49,7 +48,7 @@ class CustomsFinancialsApiConnector @Inject()(appConfig: AppConfig,
   }
 
   def isEmailUnverified(implicit hc: HeaderCarrier): Future[Option[String]] = {
-    httpClient.get(url"${appConfig.customsFinancialsApi}/subscriptions/unverified-email-display")
+    httpClient.get(url"${appConfig.customsDataStore}/subscriptions/unverified-email-display")
       .execute[EmailUnverifiedResponse]
       .flatMap {
         res => Future.successful(res.unVerifiedEmail)

--- a/app/controllers/EmailController.scala
+++ b/app/controllers/EmailController.scala
@@ -44,7 +44,7 @@ class EmailController @Inject()(authenticate: IdentifierAction,
   }
 
   def showUndeliverable(): Action[AnyContent] = authenticate async { implicit request =>
-    financialsApiConnector.getEmailaddress.map(
+    financialsApiConnector.getEmailAddress.map(
       verifiedEmailRes => Ok(undeliverableEmail(appConfig.emailFrontendUrl,
         verifiedEmailRes.verifiedEmail)(request, request.messages, appConfig)))
   }

--- a/app/controllers/EmailController.scala
+++ b/app/controllers/EmailController.scala
@@ -18,7 +18,7 @@ package controllers
 
 import actionbuilders.IdentifierAction
 import config.AppConfig
-import connectors.CustomsFinancialsApiConnector
+import connectors.CustomsDataStoreConnector
 import play.api.i18n.I18nSupport
 import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
 import play.api.{Logger, LoggerLike}
@@ -31,7 +31,7 @@ import scala.concurrent.ExecutionContext
 class EmailController @Inject()(authenticate: IdentifierAction,
                                 verifyEmailView: verify_your_email,
                                 undeliverableEmail: undeliverable_email,
-                                financialsApiConnector: CustomsFinancialsApiConnector,
+                                customsDataStoreConnector: CustomsDataStoreConnector,
                                 implicit val mcc: MessagesControllerComponents)
                                (implicit val appConfig: AppConfig, ec: ExecutionContext)
   extends FrontendController(mcc)
@@ -40,11 +40,11 @@ class EmailController @Inject()(authenticate: IdentifierAction,
   val log: LoggerLike = Logger(this.getClass)
 
   def showUnverified(): Action[AnyContent] = authenticate async { implicit request =>
-    financialsApiConnector.isEmailUnverified.map(email => Ok(verifyEmailView(appConfig.emailFrontendUrl, email)))
+    customsDataStoreConnector.isEmailUnverified.map(email => Ok(verifyEmailView(appConfig.emailFrontendUrl, email)))
   }
 
   def showUndeliverable(): Action[AnyContent] = authenticate async { implicit request =>
-    financialsApiConnector.getEmailAddress.map(
+    customsDataStoreConnector.getEmailAddress.map(
       verifiedEmailRes => Ok(undeliverableEmail(appConfig.emailFrontendUrl,
         verifiedEmailRes.verifiedEmail)(request, request.messages, appConfig)))
   }

--- a/test/connectors/CustomsDataStoreConnectorSpec.scala
+++ b/test/connectors/CustomsDataStoreConnectorSpec.scala
@@ -57,6 +57,22 @@ class CustomsDataStoreConnectorSpec
       }
     }
 
+    "return email when calling getEmailAddress" in new Setup {
+
+      running(app) {
+
+        when(requestBuilder.execute(any[HttpReads[EmailVerifiedResponse]], any[ExecutionContext]))
+          .thenReturn(Future.successful(response))
+
+        when(mockHttpClient.get(any[URL]())(any())).thenReturn(requestBuilder)
+
+        val result: Future[EmailVerifiedResponse] = customsDataStoreConnector.getEmailAddress(hc)
+        await(result) mustBe expectedResult
+
+        verifyEndPoint("http://localhost:9893/customs-data-store/subscriptions/email-display")
+      }
+    }
+
     "return unverified email" in new Setup {
 
       running(app) {

--- a/test/connectors/CustomsDataStoreConnectorSpec.scala
+++ b/test/connectors/CustomsDataStoreConnectorSpec.scala
@@ -1,0 +1,125 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package connectors
+
+import domain.{EmailUnverifiedResponse, EmailVerifiedResponse}
+import org.mockito.ArgumentCaptor
+import org.mockito.ArgumentMatchers.any
+import org.mockito.Mockito.{verify, when}
+import org.scalatest.concurrent.ScalaFutures
+import play.api.Application
+import play.api.inject.bind
+import play.api.test.Helpers.*
+import play.api.test.{DefaultAwaitTimeout, FutureAwaits}
+import uk.gov.hmrc.http.client.{HttpClientV2, RequestBuilder}
+import uk.gov.hmrc.http.{HeaderCarrier, HttpReads, HttpResponse}
+import utils.{MustMatchers, SpecBase}
+
+import java.net.URL
+import scala.concurrent.{ExecutionContext, Future}
+
+class CustomsDataStoreConnectorSpec
+  extends SpecBase
+    with ScalaFutures
+    with FutureAwaits
+    with DefaultAwaitTimeout
+    with MustMatchers {
+
+  "CustomsFinancialApiConnector" should {
+
+    "return verified email" in new Setup {
+
+      running(app) {
+
+        when(requestBuilder.execute(any[HttpReads[EmailVerifiedResponse]], any[ExecutionContext]))
+          .thenReturn(Future.successful(response))
+
+        when(mockHttpClient.get(any[URL]())(any())).thenReturn(requestBuilder)
+
+        val result: Future[EmailVerifiedResponse] = customsDataStoreConnector.isEmailVerified(hc)
+        await(result) mustBe expectedResult
+
+        verifyEndPoint("http://localhost:9893/customs-data-store/subscriptions/subscriptionsdisplay")
+      }
+    }
+
+    "return unverified email" in new Setup {
+
+      running(app) {
+
+        when(requestBuilder.execute(any[HttpReads[EmailUnverifiedResponse]], any[ExecutionContext]))
+          .thenReturn(Future.successful(EmailUnverifiedResponse(Some("unverified@email.com"))))
+
+        when(mockHttpClient.get(any[URL]())(any())).thenReturn(requestBuilder)
+
+        val result: Future[Option[String]] = customsDataStoreConnector.isEmailUnverified(hc)
+        assert(await(result).contains("unverified@email.com"))
+
+        verifyEndPoint("http://localhost:9893/customs-data-store/subscriptions/unverified-email-display")
+      }
+    }
+
+    "return None when email is not found" in new Setup {
+
+      running(app) {
+
+        when(requestBuilder.execute(any[HttpReads[EmailVerifiedResponse]], any[ExecutionContext]))
+          .thenReturn(Future.successful(EmailVerifiedResponse(None)))
+
+        when(mockHttpClient.get(any[URL]())(any())).thenReturn(requestBuilder)
+
+        val result: Future[EmailVerifiedResponse] = customsDataStoreConnector.isEmailVerified(hc)
+        await(result) mustBe EmailVerifiedResponse(None)
+      }
+    }
+  }
+
+  trait Setup {
+
+    val expectedResult: EmailVerifiedResponse = EmailVerifiedResponse(Some("verifiedEmail"))
+    implicit val hc: HeaderCarrier = HeaderCarrier()
+    val mockHttpClient: HttpClientV2 = mock[HttpClientV2]
+    val requestBuilder: RequestBuilder = mock[RequestBuilder]
+
+    val response: EmailVerifiedResponse = EmailVerifiedResponse(Some("verifiedEmail"))
+
+    when(requestBuilder.execute(any[HttpReads[EmailVerifiedResponse]], any[ExecutionContext]))
+      .thenReturn(Future.successful(response))
+
+    when(mockHttpClient.get(any[URL]())(any())).thenReturn(requestBuilder)
+
+    when(requestBuilder.withBody(any())(any(), any(), any())).thenReturn(requestBuilder)
+    when(requestBuilder.execute(any[HttpReads[HttpResponse]], any[ExecutionContext]))
+      .thenReturn(Future.successful(HttpResponse(OK, emptyString)))
+
+    when(mockHttpClient.delete(any[URL]())(any())).thenReturn(requestBuilder)
+
+    val app: Application = application().overrides(
+      bind[HttpClientV2].toInstance(mockHttpClient),
+      bind[RequestBuilder].toInstance(requestBuilder)
+    ).build()
+
+    val customsDataStoreConnector: CustomsDataStoreConnector =
+      app.injector.instanceOf[CustomsDataStoreConnector]
+
+    protected def verifyEndPoint(expectedEndPoint: String): Unit = {
+      val urlCaptor = ArgumentCaptor.forClass(classOf[URL])
+      verify(mockHttpClient).get(urlCaptor.capture)(any())
+      assert(urlCaptor.getValue.toString == expectedEndPoint)
+    }
+  }
+}

--- a/test/connectors/CustomsFinancialApiConnectorSpec.scala
+++ b/test/connectors/CustomsFinancialApiConnectorSpec.scala
@@ -75,6 +75,20 @@ class CustomsFinancialApiConnectorSpec
       }
     }
 
+    "return None when email is not found" in new Setup {
+      running(app) {
+        val connector = app.injector.instanceOf[CustomsFinancialsApiConnector]
+
+        when(requestBuilder.execute(any[HttpReads[EmailVerifiedResponse]], any[ExecutionContext]))
+          .thenReturn(Future.successful(EmailVerifiedResponse(None)))
+
+        when(mockHttpClient.get(any[URL]())(any())).thenReturn(requestBuilder)
+
+        val result: Future[EmailVerifiedResponse] = connector.isEmailVerified(hc)
+        await(result) mustBe EmailVerifiedResponse(None)
+      }
+    }
+
     "delete notifications should return a boolean based on the result" in new Setup {
 
       running(app) {

--- a/test/controllers/EmailControllerSpec.scala
+++ b/test/controllers/EmailControllerSpec.scala
@@ -16,7 +16,7 @@
 
 package controllers
 
-import connectors.CustomsFinancialsApiConnector
+import connectors.CustomsDataStoreConnector
 import domain.{EmailUnverifiedResponse, EmailVerifiedResponse}
 import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito.when
@@ -24,13 +24,14 @@ import org.mockito.ArgumentMatchers
 import play.api.Application
 import play.api.inject.bind
 import play.api.test.Helpers.*
+
 import java.net.URL
 import services.MetricsReporterService
 import utils.SpecBase
 import uk.gov.hmrc.http.client.{HttpClientV2, RequestBuilder}
-import scala.concurrent.{ExecutionContext, Future}
-import uk.gov.hmrc.http.{HeaderCarrier,HttpReads, *}
 
+import scala.concurrent.{ExecutionContext, Future}
+import uk.gov.hmrc.http.{HeaderCarrier, HttpReads, *}
 import utils.MustMatchers
 
 class EmailControllerSpec extends SpecBase with MustMatchers {
@@ -39,7 +40,7 @@ class EmailControllerSpec extends SpecBase with MustMatchers {
     "return unverified email" in new Setup {
 
       running(app) {
-        val connector = app.injector.instanceOf[CustomsFinancialsApiConnector]
+        val connector = app.injector.instanceOf[CustomsDataStoreConnector]
 
         val result: Future[Option[String]] = connector.isEmailUnverified(hc)
         await(result) mustBe expectedResult
@@ -63,8 +64,7 @@ class EmailControllerSpec extends SpecBase with MustMatchers {
         bind[RequestBuilder].toInstance(requestBuilder)
       ).build()
 
-
-      val connector: CustomsFinancialsApiConnector = app.injector.instanceOf[CustomsFinancialsApiConnector]
+      val connector: CustomsDataStoreConnector = app.injector.instanceOf[CustomsDataStoreConnector]
 
       val result: Future[EmailVerifiedResponse] = connector.isEmailVerified(hc)
 


### PR DESCRIPTION
Task:
- Modify customs-financials-frontend repo so that it retrieves email addresses using the customs-data-store instead of the customs-financials-api.
- Add or amend unit tests.