### PR TITLE
MMCA-4894 | Landing page notification for Requested Cash Account Transactions

### DIFF
--- a/app/controllers/CustomsFinancialsHomeController.scala
+++ b/app/controllers/CustomsFinancialsHomeController.scala
@@ -50,7 +50,7 @@ class CustomsFinancialsHomeController @Inject()(authenticate: IdentifierAction,
                                                 accountNotAvailable: account_not_available,
                                                 sessionCacheConnector: CustomsFinancialsSessionCacheConnector,
                                                 secureMessageConnector: SecureMessageConnector,
-                                                customsManageAuthConnector:CustomsManageAuthoritiesConnector,
+                                                customsManageAuthConnector: CustomsManageAuthoritiesConnector,
                                                 implicit val mcc: MessagesControllerComponents)
                                                (implicit val appConfig: AppConfig, ec: ExecutionContext)
   extends FrontendController(mcc) with I18nSupport {
@@ -171,6 +171,7 @@ class CustomsFinancialsHomeController @Inject()(authenticate: IdentifierAction,
     }
 
     val authorityMessage = authoritiesNotification.map(notification => s"${notification.fileRole.messageKey}")
+
     authorityMessage ++ requestedMessages ++ statementMessages
   }
 

--- a/app/domain/CashAccountStatementsByMonth.scala
+++ b/app/domain/CashAccountStatementsByMonth.scala
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package domain
+
+import domain.FileFormat.{Csv, Pdf}
+import play.api.i18n.Messages
+import views.helpers.Formatters
+
+import java.time.LocalDate
+
+case class CashAccountStatementsByMonth(date: LocalDate,
+                                        files: Seq[CashAccountStatementFile])
+                                       (implicit messages: Messages
+                                       ) extends Ordered[CashAccountStatementsByMonth] {
+
+  val formattedMonth: String = Formatters.dateAsMonth(date)
+  val formattedMonthYear: String = Formatters.dateAsMonthAndYear(date)
+  val pdf: Option[CashAccountStatementFile] = files.find(_.fileFormat == Pdf)
+  val csv: Option[CashAccountStatementFile] = files.find(_.fileFormat == Csv)
+
+  override def compare(that: CashAccountStatementsByMonth): Int = date.compareTo(that.date)
+}

--- a/app/domain/CashAccountStatementsByMonth.scala
+++ b/app/domain/CashAccountStatementsByMonth.scala
@@ -24,8 +24,7 @@ import java.time.LocalDate
 
 case class CashAccountStatementsByMonth(date: LocalDate,
                                         files: Seq[CashAccountStatementFile])
-                                       (implicit messages: Messages
-                                       ) extends Ordered[CashAccountStatementsByMonth] {
+                                       (implicit messages: Messages) extends Ordered[CashAccountStatementsByMonth] {
 
   val formattedMonth: String = Formatters.dateAsMonth(date)
   val formattedMonthYear: String = Formatters.dateAsMonthAndYear(date)

--- a/app/domain/SdesFile.scala
+++ b/app/domain/SdesFile.scala
@@ -136,7 +136,9 @@ object FileRole {
     "StandingAuthority", "authorities", "Display standing authorities csv", "authorities")
 
   case object CashAccountStatement extends FileRole(
-    "CashAccountStatement", "cash-account-statement", "Display Cash Account Statements", "cash-account-statement")
+    "CashAccountStatement", "cash-account-statement",
+    "Display Cash Account Statements", "requested-cash-account-statement"
+  )
 
   val log: LoggerLike = Logger(this.getClass)
 
@@ -323,3 +325,23 @@ case class PostponedVatStatementFileMetadata(periodStartYear: Int,
                                              fileRole: FileRole,
                                              source: String,
                                              statementRequestId: Option[String]) extends SdesFileMetadata
+
+case class CashAccountStatementFile(filename: String,
+                                    downloadURL: String,
+                                    size: Long,
+                                    metadata: CashAccountStatementFileMetadata,
+                                    eori: String)
+                                   (implicit messages: Messages
+                                   ) extends Ordered[CashAccountStatementFile] with SdesFile {
+
+  val formattedSize: String = Formatters.fileSize(size)
+  val formattedMonth: String = Formatters.dateAsMonth(monthAndYear)
+
+  def compare(that: CashAccountStatementFile): Int = that.metadata.fileFormat.compare(metadata.fileFormat)
+}
+
+case class CashAccountStatementFileMetadata(periodStartYear: Int,
+                                            periodStartMonth: Int,
+                                            fileFormat: FileFormat,
+                                            fileRole: FileRole,
+                                            statementRequestId: Option[String]) extends SdesFileMetadata

--- a/app/domain/SdesFile.scala
+++ b/app/domain/SdesFile.scala
@@ -135,6 +135,9 @@ object FileRole {
   case object StandingAuthority extends FileRole(
     "StandingAuthority", "authorities", "Display standing authorities csv", "authorities")
 
+  case object CashAccountStatement extends FileRole(
+    "CashAccountStatement", "cash-account-statement", "Display Cash Account Statements", "cash-account-statement")
+
   val log: LoggerLike = Logger(this.getClass)
 
   def apply(name: String): FileRole = name match {
@@ -144,6 +147,7 @@ object FileRole {
     case "PostponedVATAmendedStatement" => PostponedVATAmendedStatement
     case "SecurityStatement" => SecurityStatement
     case "StandingAuthority" => StandingAuthority
+    case "CashAccountStatement" => CashAccountStatement
     case _ => throw new Exception(s"Unknown file role: $name")
   }
 
@@ -163,6 +167,7 @@ object FileRole {
         case "duty-deferment" => Right(DutyDefermentStatement)
         case "adjustments" => Right(SecurityStatement)
         case "authorities" => Right(StandingAuthority)
+        case "cash-account-statement" => Right(CashAccountStatement)
         case fileRole => Left(s"unknown file role: ${fileRole}")
       }
     }
@@ -174,6 +179,7 @@ object FileRole {
         case DutyDefermentStatement => "duty-deferment"
         case SecurityStatement => "adjustments"
         case StandingAuthority => "authorities"
+        case CashAccountStatement => "cash-account-statement"
         case _ => "unsupported-file-role"
       }
     }

--- a/app/domain/SdesFile.scala
+++ b/app/domain/SdesFile.scala
@@ -330,9 +330,8 @@ case class CashAccountStatementFile(filename: String,
                                     downloadURL: String,
                                     size: Long,
                                     metadata: CashAccountStatementFileMetadata,
-                                    eori: String)
-                                   (implicit messages: Messages
-                                   ) extends Ordered[CashAccountStatementFile] with SdesFile {
+                                    eori: String)(implicit messages: Messages) extends Ordered[CashAccountStatementFile]
+  with SdesFile {
 
   val formattedSize: String = Formatters.fileSize(size)
   val formattedMonth: String = Formatters.dateAsMonth(monthAndYear)

--- a/conf/messages.cy
+++ b/conf/messages.cy
@@ -170,6 +170,7 @@ cf.customs-financials-home.notification.requested-c79=Mae’r tystysgrifau TAW m
 cf.customs-financials-home.notification.requested-duty-deferment=Mae’r datganiadau gohirio tollau y gofynnwyd amdanynt gennych ar gael i’w gweld
 cf.customs-financials-home.notification.requested-adjustments=Mae’r datganiadau addasiadau mewnforio y gofynnwyd amdanynt gennych ar gael i’w gweld
 cf.customs-financials-home.notification.requested-postponed-vat=Mae’r datganiadau ar gyfer TAW mewnforio ohiriedig y gofynnoch amdanynt ar gael i’w gweld
+cf.customs-financials-home.notification.requested-cash-account-statement=Mae’r trafodion cyfrif arian parod y gwnaethoch gais amdanynt yn barod i’w gweld
 cf.customs-financials-home.notification.authorities=Mae’r rhestr o gyfrifon y gwnaethoch gais amdanynt ac y mae gennych yr awdurdod i’w defnyddio ar gael
 
 # Verify Your Email Address

--- a/conf/messages.cy
+++ b/conf/messages.cy
@@ -170,7 +170,7 @@ cf.customs-financials-home.notification.requested-c79=Mae’r tystysgrifau TAW m
 cf.customs-financials-home.notification.requested-duty-deferment=Mae’r datganiadau gohirio tollau y gofynnwyd amdanynt gennych ar gael i’w gweld
 cf.customs-financials-home.notification.requested-adjustments=Mae’r datganiadau addasiadau mewnforio y gofynnwyd amdanynt gennych ar gael i’w gweld
 cf.customs-financials-home.notification.requested-postponed-vat=Mae’r datganiadau ar gyfer TAW mewnforio ohiriedig y gofynnoch amdanynt ar gael i’w gweld
-cf.customs-financials-home.notification.requested-cash-account-statement=Mae’r trafodion cyfrif arian parod y gwnaethoch gais amdanynt yn barod i’w gweld
+cf.customs-financials-home.notification.requested-cash-account-statement=Mae’r trafodion cyfrif arian parod y gwnaethoch gais amdanynt yn barod i’w gweld.
 cf.customs-financials-home.notification.authorities=Mae’r rhestr o gyfrifon y gwnaethoch gais amdanynt ac y mae gennych yr awdurdod i’w defnyddio ar gael
 
 # Verify Your Email Address

--- a/conf/messages.en
+++ b/conf/messages.en
@@ -167,6 +167,7 @@ cf.customs-financials-home.notification.requested-duty-deferment=Your requested 
 cf.customs-financials-home.notification.requested-adjustments=Your requested import adjustments statements are available to view
 cf.customs-financials-home.notification.requested-postponed-vat=Your requested postponed import VAT statements are available to view
 cf.customs-financials-home.notification.authorities=Your requested list of accounts you have authority to use is available
+cf.customs-financials-home.notification.cash-account-statement=Your requested cash account statements are available to view
 
 # Verify Your Email Address
 cf.verify.your.email.title=Verify your email address for the Customs Declaration Service

--- a/conf/messages.en
+++ b/conf/messages.en
@@ -166,8 +166,8 @@ cf.customs-financials-home.notification.requested-c79=Your requested import VAT 
 cf.customs-financials-home.notification.requested-duty-deferment=Your requested duty deferment statements are available to view
 cf.customs-financials-home.notification.requested-adjustments=Your requested import adjustments statements are available to view
 cf.customs-financials-home.notification.requested-postponed-vat=Your requested postponed import VAT statements are available to view
+cf.customs-financials-home.notification.requested-cash-account-statement=Your requested cash account transactions are available to view
 cf.customs-financials-home.notification.authorities=Your requested list of accounts you have authority to use is available
-cf.customs-financials-home.notification.cash-account-statement=Your requested cash account statements are available to view
 
 # Verify Your Email Address
 cf.verify.your.email.title=Verify your email address for the Customs Declaration Service

--- a/conf/messages.en
+++ b/conf/messages.en
@@ -166,7 +166,7 @@ cf.customs-financials-home.notification.requested-c79=Your requested import VAT 
 cf.customs-financials-home.notification.requested-duty-deferment=Your requested duty deferment statements are available to view
 cf.customs-financials-home.notification.requested-adjustments=Your requested import adjustments statements are available to view
 cf.customs-financials-home.notification.requested-postponed-vat=Your requested postponed import VAT statements are available to view
-cf.customs-financials-home.notification.requested-cash-account-statement=Your requested cash account transactions are available to view
+cf.customs-financials-home.notification.requested-cash-account-statement=Your requested cash account transactions are available to view.
 cf.customs-financials-home.notification.authorities=Your requested list of accounts you have authority to use is available
 
 # Verify Your Email Address

--- a/test/controllers/HomeControllerSpec.scala
+++ b/test/controllers/HomeControllerSpec.scala
@@ -18,19 +18,12 @@ package controllers
 
 import config.AppConfig
 import connectors.{CustomsFinancialsSessionCacheConnector, CustomsManageAuthoritiesConnector}
-import domain.FileRole.{
-  C79Certificate, DutyDefermentStatement, PostponedVATAmendedStatement, PostponedVATStatement,
-  SecurityStatement, StandingAuthority
-}
-import domain.{
-  AccountStatusOpen, CDSAccount, CDSAccounts, CDSCashBalance, CashAccount, DefermentAccountAvailable,
-  DutyDefermentAccount, DutyDefermentBalance, GeneralGuaranteeAccount, GeneralGuaranteeBalance, XiEoriAddressInformation
-}
+import domain.FileRole._
+import domain._
 import org.jsoup.Jsoup
 import org.mockito.ArgumentMatchers.{any, eq => eqTo}
 import org.mockito.Mockito.when
 import utils.MustMatchers
-
 import play.api.http.Status
 import play.api.i18n.Messages
 import play.api.mvc.Results.Ok
@@ -213,6 +206,21 @@ class HomeControllerSpec extends SpecBase with MustMatchers {
 
   "show notification when there is new Standing authorities csv file available" in new Setup {
     val notifications: List[Notification] = List(Notification(StandingAuthority, isRequested = false))
+
+    when(mockNotificationService.fetchNotifications(eqTo(eoriNumber))(any)).thenReturn(
+      Future.successful(notifications))
+
+    running(app) {
+      val request = fakeRequest(GET, routes.CustomsFinancialsHomeController.index.url)
+      val result = route(app, request).value
+      val html = Jsoup.parse(contentAsString(result))
+
+      html.containsElementById("notification-panel")
+    }
+  }
+
+  "show notification when there is new Cash Account Statement file available" in new Setup {
+    val notifications: List[Notification] = List(Notification(CashAccountStatement, isRequested = false))
 
     when(mockNotificationService.fetchNotifications(eqTo(eoriNumber))(any)).thenReturn(
       Future.successful(notifications))

--- a/test/domain/CashAccountStatementByMonthSpec.scala
+++ b/test/domain/CashAccountStatementByMonthSpec.scala
@@ -1,0 +1,114 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package domain
+
+import domain.FileFormat.{Csv, Pdf}
+import domain.FileRole.SecurityStatement
+import play.api.Application
+import play.api.i18n.Messages
+import utils.{MustMatchers, SpecBase}
+
+import java.time.LocalDate
+
+class CashAccountStatementByMonthSpec extends SpecBase with MustMatchers {
+
+  "formattedMonth" should {
+    "return correct formatted value for the month" in new Setup {
+      cashAccountStatementByMonthWithPdf.formattedMonth mustBe "October"
+    }
+  }
+
+  "formattedMonthYear" should {
+    "return correct formatted Month and year string" in new Setup {
+      cashAccountStatementByMonthWithPdf.formattedMonthYear mustBe "October 2023"
+    }
+  }
+
+  "pdf" should {
+    "return CashAccountStatementFile when files has pdf format" in new Setup {
+      cashAccountStatementByMonthWithPdf.pdf mustBe Some(cashAccountStatementFilePdf)
+    }
+
+    "return None when files has no file with pdf format" in new Setup {
+      cashAccountStatementByMonthWithCsv.pdf mustBe empty
+    }
+  }
+
+  "csv" should {
+    "return CashAccountStatementFile when files has csv format" in new Setup {
+      cashAccountStatementByMonthWithCsv.csv mustBe Some(cashAccountStatementFileCsv)
+    }
+
+    "return None when files has no file with csv format" in new Setup {
+      cashAccountStatementByMonthWithPdf.csv mustBe empty
+    }
+  }
+
+  "compare" should {
+    "sort correctly" in new Setup {
+      List(cashAccountStatementByMonthWithCsv,
+        cashAccountStatementByMonthWithPdf
+      ).sorted mustBe List(cashAccountStatementByMonthWithPdf, cashAccountStatementByMonthWithCsv)
+    }
+  }
+
+  trait Setup {
+    val startYear = 2023
+    val endYear = 2023
+
+    val year = 2023
+    val month = 10
+    val day = 8
+    val eori = "test_eori"
+
+    val fileName = "test_file"
+    val downloadUrl = "test_url"
+    val size = 2048
+
+    val date: LocalDate = LocalDate.of(year, month, day)
+
+    val app: Application = application().build()
+    implicit val msgs: Messages = messages(app)
+
+    val metadataWithPdf: CashAccountStatementFileMetadata = CashAccountStatementFileMetadata(
+      startYear, month, Pdf, SecurityStatement, None)
+
+    val metadataWithCsv: CashAccountStatementFileMetadata = CashAccountStatementFileMetadata(
+      startYear, month, Csv, SecurityStatement, None)
+
+    val cashAccountStatementFilePdf: CashAccountStatementFile = CashAccountStatementFile(
+      fileName,
+      downloadUrl,
+      size,
+      metadataWithPdf,
+      eori
+    )
+
+    val cashAccountStatementFileCsv: CashAccountStatementFile = CashAccountStatementFile(fileName,
+      downloadUrl,
+      size,
+      metadataWithCsv,
+      eori
+    )
+
+    val cashAccountStatementByMonthWithPdf: CashAccountStatementsByMonth =
+      CashAccountStatementsByMonth(date, Seq(cashAccountStatementFilePdf))
+
+    val cashAccountStatementByMonthWithCsv: CashAccountStatementsByMonth =
+      CashAccountStatementsByMonth(date.plusMonths(1), Seq(cashAccountStatementFileCsv))
+  }
+}

--- a/test/domain/SdesFileSpec.scala
+++ b/test/domain/SdesFileSpec.scala
@@ -252,6 +252,40 @@ class SdesFileSpec extends SpecBase with MustMatchers {
     }
   }
 
+  "CashAccountStatementFile" should {
+    "return correct output for formattedSize" in new Setup {
+      cashAccountStatementFile.formattedSize mustBe Formatters.fileSize(FILE_SIZE_2164)
+    }
+
+    "return correct output for formattedMonth" in new Setup {
+      cashAccountStatementFile.formattedMonth mustBe "month.10"
+    }
+
+    "sort the files correctly" in new Setup {
+      val cashAccountStatementFile1: CashAccountStatementFile = CashAccountStatementFile(
+        filename = fileName,
+        downloadURL = downloadUrl,
+        size = size,
+        metadata = cashAccountStatementFileMetadata,
+        eori = eori
+      )
+
+      val cashAccountStatementFile2: CashAccountStatementFile = CashAccountStatementFile(
+        filename = fileName,
+        downloadURL = downloadUrl,
+        size = size,
+        metadata = cashAccountStatementFileMetadata.copy(
+          periodStartYear = cashAccountStatementFileMetadata.periodStartYear + 1,
+          fileFormat = Csv
+        ),
+        eori = eori
+      )
+
+      List(cashAccountStatementFile1, cashAccountStatementFile2)
+        .sorted mustBe List(cashAccountStatementFile1, cashAccountStatementFile2)
+    }
+  }
+
   "FileFormat" should {
     "generate correct output" when {
       "reads" in new Setup {
@@ -295,11 +329,21 @@ class SdesFileSpec extends SpecBase with MustMatchers {
     val vatCertificateFileMetadata: VatCertificateFileMetadata =
       VatCertificateFileMetadata(YEAR_2010, MONTH_1, Csv, FileRole.C79Certificate, None)
 
+    val cashAccountStatementFileMetadata: CashAccountStatementFileMetadata =
+      CashAccountStatementFileMetadata(startYear, month, Csv, FileRole.CashAccountStatement, None)
+
     val vatCertFile: VatCertificateFile = VatCertificateFile("test_file_name",
       "test_url",
       FILE_SIZE_2164,
       vatCertificateFileMetadata,
       "test_eori")
+
+    val cashAccountStatementFile: CashAccountStatementFile = CashAccountStatementFile(
+      filename = "test_file_name",
+      downloadURL = "test_url",
+      size = FILE_SIZE_2164,
+      metadata = cashAccountStatementFileMetadata,
+      eori = "test_eori")
 
     def randomInt(limit: Int): Int = Random.nextInt(limit)
 

--- a/test/domain/SdesFileSpec.scala
+++ b/test/domain/SdesFileSpec.scala
@@ -19,14 +19,12 @@ package domain
 import domain.DDStatementType.{Excise, Supplementary, UnknownStatementType, Weekly}
 import domain.DutyPaymentMethod.CDS
 import domain.FileFormat.{Csv, Pdf, UnknownFileFormat}
-import domain.FileRole.{C79Certificate, DutyDefermentStatement, PostponedVATAmendedStatement, PostponedVATStatement, SecurityStatement, StandingAuthority}
-
+import domain.FileRole._
 import play.api.i18n.Messages
 import play.api.libs.json.{JsString, JsSuccess, Json}
 import play.api.test.Helpers.stubMessages
 import utils.SpecBase
-import utils.TestData.{DAY_2, DAY_20, FILE_SIZE_2064, FILE_SIZE_2164, FILE_SIZE_DEFAULT, LENGTH_11, LENGTH_27, LENGTH_8,
-  MONTH_1, MONTH_2, YEAR_1972, YEAR_2010, YEAR_2017}
+import utils.TestData._
 import views.helpers.Formatters
 import utils.MustMatchers
 
@@ -59,6 +57,7 @@ class SdesFileSpec extends SpecBase with MustMatchers {
       FileRole("PostponedVATAmendedStatement") mustBe PostponedVATAmendedStatement
       FileRole("SecurityStatement") mustBe SecurityStatement
       FileRole("StandingAuthority") mustBe StandingAuthority
+      FileRole("CashAccountStatement") mustBe CashAccountStatement
 
       intercept[Exception] {
         FileRole("Unknown")
@@ -84,6 +83,7 @@ class SdesFileSpec extends SpecBase with MustMatchers {
       Json.fromJson(JsString("PostponedVATAmendedStatement")) mustBe JsSuccess(FileRole("PostponedVATAmendedStatement"))
       Json.fromJson(JsString("SecurityStatement")) mustBe JsSuccess(FileRole("SecurityStatement"))
       Json.fromJson(JsString("StandingAuthority")) mustBe JsSuccess(FileRole("StandingAuthority"))
+      Json.fromJson(JsString("CashAccountStatement")) mustBe JsSuccess(FileRole("CashAccountStatement"))
     }
 
     "return correct output for Writes" in new Setup {
@@ -98,6 +98,7 @@ class SdesFileSpec extends SpecBase with MustMatchers {
       pathBinder.bind(emptyString, "duty-deferment") mustBe Right(DutyDefermentStatement)
       pathBinder.bind(emptyString, "adjustments") mustBe Right(SecurityStatement)
       pathBinder.bind(emptyString, "authorities") mustBe Right(StandingAuthority)
+      pathBinder.bind(emptyString, "cash-account-statement") mustBe Right(CashAccountStatement)
       pathBinder.bind(emptyString, "unknown") mustBe Left(s"unknown file role: unknown")
     }
 
@@ -109,6 +110,7 @@ class SdesFileSpec extends SpecBase with MustMatchers {
       pathBinder.unbind(emptyString, DutyDefermentStatement) mustBe "duty-deferment"
       pathBinder.unbind(emptyString, SecurityStatement) mustBe "adjustments"
       pathBinder.unbind(emptyString, StandingAuthority) mustBe "authorities"
+      pathBinder.unbind(emptyString, CashAccountStatement) mustBe "cash-account-statement"
     }
   }
 

--- a/test/services/NotificationServiceSpec.scala
+++ b/test/services/NotificationServiceSpec.scala
@@ -16,7 +16,7 @@
 
 package services
 
-import domain.FileRole.{C79Certificate, DutyDefermentStatement, PostponedVATStatement, SecurityStatement, StandingAuthority}
+import domain.FileRole._
 import org.mockito.ArgumentMatchers.{eq => eqTo}
 import org.mockito.Mockito.{verify, when, reset}
 import org.scalatest.BeforeAndAfterEach
@@ -49,6 +49,7 @@ class NotificationServiceSpec
   "Notification service" should {
 
     "indicate that notifications are available" when {
+
       val collectionOfDocumentAttributes = List(
         DocumentAttributes(eori, C79Certificate, "new file", fileSize, Map.empty),
         DocumentAttributes(eori, PostponedVATStatement, "new file", fileSize, Map.empty),
@@ -60,7 +61,8 @@ class NotificationServiceSpec
           "statementRequestID" -> "3jh9f9b9-f9b9-9f9c-999a-36701e99d9")),
         DocumentAttributes(eori, SecurityStatement, "new file", fileSize, Map(
           "statementRequestID" -> "3jh9f9b9-f9b9-9f9c-999a-37701e99d9")),
-        DocumentAttributes(eori, StandingAuthority, "new file", fileSize, Map.empty)
+        DocumentAttributes(eori, StandingAuthority, "new file", fileSize, Map.empty),
+        DocumentAttributes(eori, CashAccountStatement, "new file", fileSize, Map.empty)
       )
 
       "the given document type is present" in {
@@ -78,7 +80,8 @@ class NotificationServiceSpec
           Notification(C79Certificate, isRequested = true),
           Notification(DutyDefermentStatement, isRequested = true),
           Notification(SecurityStatement, isRequested = true),
-          Notification(StandingAuthority, isRequested = false)
+          Notification(StandingAuthority, isRequested = false),
+          Notification(CashAccountStatement, isRequested = false)
         )
 
         val actualNotification = await(notificationService.fetchNotifications(eori))

--- a/test/views/components/NotificationPanelSpec.scala
+++ b/test/views/components/NotificationPanelSpec.scala
@@ -180,5 +180,25 @@ class NotificationPanelSpec extends SpecBase with MustMatchers {
           "cf.customs-financials-home.notification.authorities").isEmpty mustBe true
       }
     }
+
+    "display Cash Account Statement notification" when {
+      "new Cash Account Statement file is available" in {
+        val messageKeys = List("cash-account-statement")
+        val expected = List("cf.customs-financials-home.notification.cash-account-statement")
+        val content = Jsoup.parse(views.html.components.notification_panel(messageKeys).body)
+
+        content.select("#notification-panel p").asScala.map(_.text()).toList mustBe expected
+      }
+    }
+
+    "not display Cash Account Statement notification" when {
+      "there is no new Cash Account Statement file" in {
+        val messageKeys = List()
+        val content = Jsoup.parse(views.html.components.notification_panel(messageKeys).body)
+
+        content.getElementsContainingText(
+          "cf.customs-financials-home.notification.cash-account-statement").isEmpty mustBe true
+      }
+    }
   }
 }


### PR DESCRIPTION
Task:
- On login, check mongodb for cash account statement notification in the notification-store collection
- Display the notification on the landing page