### PR TITLE
[MMCA -4915] - Feature flag to enable to switch to new Cash Account page

### DIFF
--- a/app/config/AppConfig.scala
+++ b/app/config/AppConfig.scala
@@ -38,6 +38,7 @@ class AppConfig @Inject()(val config: Configuration, servicesConfig: ServicesCon
   lazy val xClientIdHeader: String = config.get[String]("microservice.services.sdes.x-client-id")
   lazy val fixedDateTime: Boolean = config.get[Boolean]("features.fixed-system-time")
   lazy val xiEoriEnabled: Boolean = config.get[Boolean]("features.xi-eori-enabaled")
+  lazy val isCashAccountV2FeatureFlagEnabled: Boolean = config.get[Boolean]("features.cash-account-v2-enabled")
 
   lazy val subscribeCdsUrl: String = config.get[String]("external-urls.cdsSubscribeUrl")
   lazy val reportChangeCdsUrl: String = config.get[String]("external-urls.reportChangeUrl")
@@ -54,7 +55,13 @@ class AppConfig @Inject()(val config: Configuration, servicesConfig: ServicesCon
   lazy val financialsFrontendUrl: String =
     config.get[String]("microservice.services.customs-financials-frontend.url")
 
-  lazy val cashAccountUrl: String = config.get[String]("microservice.services.customs-cash-account-frontend.url")
+  lazy val cashAccountUrl: String =
+    if(isCashAccountV2FeatureFlagEnabled) {
+      config.get[String]("microservice.services.customs-cash-account-frontend.urlV2")
+    } else {
+      config.get[String]("microservice.services.customs-cash-account-frontend.url")
+    }
+
   lazy val manageAuthoritiesFrontendUrl: String =
     config.get[String]("microservice.services.customs-manage-authorities-frontend.url")
 

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -98,6 +98,7 @@ microservice {
 
     customs-cash-account-frontend {
       url = "http://localhost:9394/customs/cash-account"
+      urlV2 = "http://localhost:9394/customs/cash-account/v2"
     }
 
     customs-guarantee-account-frontend {
@@ -187,6 +188,7 @@ tracking-consent-frontend {
 features {
   fixed-system-time: false
   xi-eori-enabaled: true
+  cash-account-v2-enabled: false
   # Don't enable features globally here... use app-config-<env> to target specific environments
   # Enable features locally with `sbt "run -Dfeatures.some-feature-name=true"`
 }

--- a/test/config/AppConfigSpec.scala
+++ b/test/config/AppConfigSpec.scala
@@ -74,6 +74,8 @@ class AppConfigSpec extends SpecBase with ShouldMatchers {
 
   "isCashAccountV2FeatureFlagEnabled" should {
     "return the correct value" in new Setup {
+      assume(!appConfig.isCashAccountV2FeatureFlagEnabled)
+
       appConfig.isCashAccountV2FeatureFlagEnabled shouldBe false
     }
   }
@@ -82,6 +84,8 @@ class AppConfigSpec extends SpecBase with ShouldMatchers {
 
     "return the correct url" when {
       "isCashAccountV2FeatureFlagEnabled is disabled" in new Setup {
+        assume(!appConfig.isCashAccountV2FeatureFlagEnabled)
+
         appConfig.cashAccountUrl shouldBe "http://localhost:9394/customs/cash-account"
       }
     }

--- a/test/config/AppConfigSpec.scala
+++ b/test/config/AppConfigSpec.scala
@@ -72,6 +72,21 @@ class AppConfigSpec extends SpecBase with ShouldMatchers {
     }
   }
 
+  "isCashAccountV2FeatureFlagEnabled" should {
+    "return the correct value" in new Setup {
+      appConfig.isCashAccountV2FeatureFlagEnabled shouldBe false
+    }
+  }
+
+  "cashAccountUrl" should {
+
+    "return the correct url" when {
+      "isCashAccountV2FeatureFlagEnabled is disabled" in new Setup {
+        appConfig.cashAccountUrl shouldBe "http://localhost:9394/customs/cash-account"
+      }
+    }
+  }
+
   trait Setup {
     val app: Application = application().build()
     val appConfig: AppConfig = app.injector.instanceOf[AppConfig]


### PR DESCRIPTION
Description - Add new feature flag named cash-account-v2-enabled is added to enable to switch to new cash account page when it is true

Below has been done as part of this PR

- add new feature flag named cash-account-v2-enabled
- add tests
- add new config for new cash account url