### PR TITLE
MMCA-4974 | Display updated message on 'Manage your account authorities' page in case of no authorised accounts

### DIFF
--- a/app/config/AppConfig.scala
+++ b/app/config/AppConfig.scala
@@ -39,6 +39,7 @@ class AppConfig @Inject()(val config: Configuration, servicesConfig: ServicesCon
   lazy val fixedDateTime: Boolean = config.get[Boolean]("features.fixed-system-time")
   lazy val xiEoriEnabled: Boolean = config.get[Boolean]("features.xi-eori-enabaled")
   lazy val isCashAccountV2FeatureFlagEnabled: Boolean = config.get[Boolean]("features.cash-account-v2-enabled")
+  lazy val isHomePageLinksEnabled: Boolean = config.get[Boolean]("features.home-page-links-enabled")
 
   lazy val subscribeCdsUrl: String = config.get[String]("external-urls.cdsSubscribeUrl")
   lazy val reportChangeCdsUrl: String = config.get[String]("external-urls.reportChangeUrl")
@@ -56,7 +57,7 @@ class AppConfig @Inject()(val config: Configuration, servicesConfig: ServicesCon
     config.get[String]("microservice.services.customs-financials-frontend.url")
 
   lazy val cashAccountUrl: String =
-    if(isCashAccountV2FeatureFlagEnabled) {
+    if (isCashAccountV2FeatureFlagEnabled) {
       config.get[String]("microservice.services.customs-cash-account-frontend.urlV2")
     } else {
       config.get[String]("microservice.services.customs-cash-account-frontend.url")

--- a/app/views/dashboard/customs_financials_home.scala.html
+++ b/app/views/dashboard/customs_financials_home.scala.html
@@ -46,6 +46,19 @@
 
     @h1("cf.customs-financials-home.title", classes = "govuk-heading-xl govuk-!-margin-bottom-4")
 
+    @if(appConfig.isHomePageLinksEnabled) {
+      @link("cf.account.manage-account-authorities.title",
+        appConfig.manageAuthoritiesFrontendUrl,
+        pWrapped = false,
+        linkId = Some("manage-account-authorities-link"),
+        linkClass = "govuk-link govuk-!-margin-right-2")
+
+      @link("cf.account.authorized-to-view.title",
+        controllers.routes.AuthorizedToViewController.onPageLoad().url,
+        linkId = Some("authorised-to-view-link"),
+        pWrapped = false)
+    }
+
     @notification_panel(model.notificationMessageKeys)
 
     @cashAccountCards(model.cashAccounts)

--- a/app/views/dashboard/customs_financials_home.scala.html
+++ b/app/views/dashboard/customs_financials_home.scala.html
@@ -46,20 +46,6 @@
 
     @h1("cf.customs-financials-home.title", classes = "govuk-heading-xl govuk-!-margin-bottom-4")
 
-    @link("cf.account.manage-account-authorities.title",
-            appConfig.manageAuthoritiesFrontendUrl,
-            pWrapped = false,
-            linkId = Some("manage-account-authorities-link"),
-            linkClass = "govuk-link govuk-!-margin-right-2"
-    )
-
-    @link(
-            "cf.account.authorized-to-view.title",
-            controllers.routes.AuthorizedToViewController.onPageLoad().url,
-            linkId = Some("authorised-to-view-link"),
-            pWrapped = false
-    )
-
     @notification_panel(model.notificationMessageKeys)
 
     @cashAccountCards(model.cashAccounts)

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -189,6 +189,7 @@ features {
   fixed-system-time: false
   xi-eori-enabaled: true
   cash-account-v2-enabled: false
+  home-page-links-enabled: true
   # Don't enable features globally here... use app-config-<env> to target specific environments
   # Enable features locally with `sbt "run -Dfeatures.some-feature-name=true"`
 }

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -189,7 +189,7 @@ features {
   fixed-system-time: false
   xi-eori-enabaled: true
   cash-account-v2-enabled: false
-  home-page-links-enabled: true
+  home-page-links-enabled: false
   # Don't enable features globally here... use app-config-<env> to target specific environments
   # Enable features locally with `sbt "run -Dfeatures.some-feature-name=true"`
 }

--- a/test/config/AppConfigSpec.scala
+++ b/test/config/AppConfigSpec.scala
@@ -80,6 +80,12 @@ class AppConfigSpec extends SpecBase with ShouldMatchers {
     }
   }
 
+  "isHomePageLinksEnabled" should {
+    "return the correct value" in new Setup {
+      appConfig.isHomePageLinksEnabled shouldBe true
+    }
+  }
+
   "cashAccountUrl" should {
 
     "return the correct url" when {

--- a/test/config/AppConfigSpec.scala
+++ b/test/config/AppConfigSpec.scala
@@ -82,7 +82,7 @@ class AppConfigSpec extends SpecBase with ShouldMatchers {
 
   "isHomePageLinksEnabled" should {
     "return the correct value" in new Setup {
-      appConfig.isHomePageLinksEnabled shouldBe true
+      appConfig.isHomePageLinksEnabled shouldBe false
     }
   }
 

--- a/test/views/HomeViewSpec.scala
+++ b/test/views/HomeViewSpec.scala
@@ -42,6 +42,20 @@ class HomeViewSpec extends SpecBase {
         page(modelWithAgentAccess, None).containsLinkWithText("#", "View your customs financial accounts")
       }
     }
+
+    "display other accounts you can use link" when {
+      "agent has access to other accounts with AuthorisedToView" in new Setup {
+        running(app) {
+          page(modelWithAgentAccess, None).containsLink("/customs/payment-records/authorized-to-view?page=1")
+        }
+      }
+    }
+
+    "display manage your account authorities link" in new Setup {
+      running(app) {
+        page(modelWithAgentAccess, None).containsLink("http://localhost:9000/customs/manage-authorities")
+      }
+    }
   }
 
   "not display manage your account authorities link" when {

--- a/test/views/HomeViewSpec.scala
+++ b/test/views/HomeViewSpec.scala
@@ -42,20 +42,6 @@ class HomeViewSpec extends SpecBase {
         page(modelWithAgentAccess, None).containsLinkWithText("#", "View your customs financial accounts")
       }
     }
-
-    "display other accounts you can use link" when {
-      "agent has access to other accounts with AuthorisedToView" in new Setup {
-        running(app) {
-          page(modelWithAgentAccess, None).containsLink("/customs/payment-records/authorized-to-view?page=1")
-        }
-      }
-    }
-
-    "display manage your account authorities link" in new Setup {
-      running(app) {
-        page(modelWithAgentAccess, None).containsLink("http://localhost:9000/customs/manage-authorities")
-      }
-    }
   }
 
   "not display manage your account authorities link" when {
@@ -93,6 +79,12 @@ class HomeViewSpec extends SpecBase {
       "displays Your contact details as a link text" in new Setup {
         running(app) {
           page(modelWithAgentAccess, None).containsLinkWithText("#", "Your contact details")
+        }
+      }
+
+      "displays Your account authorities as a link text" in new Setup {
+        running(app) {
+          page(modelWithAgentAccess, None).containsLinkWithText("#", "Your account authorities")
         }
       }
     }


### PR DESCRIPTION
**Context:**
This story displays a guidance message in case no accounts are authorised.

**Dev Tasks:**
- [x] Show links only on flag
- [x] Amend / add unit tests