### PR TITLE
[MMCA-4977] - Implement the existing header bar with all tabs on 'Your Contact Details' page

### DIFF
--- a/app/controllers/YourContactDetailsController.scala
+++ b/app/controllers/YourContactDetailsController.scala
@@ -84,7 +84,7 @@ class YourContactDetailsController @Inject()(authenticate: IdentifierAction,
                            appConfig: AppConfig,
                            requestHeader: RequestHeader): Future[Result] = {
     val returnToUrl =
-      s"${appConfig.financialsFrontendUrl}${controllers.routes.CustomsFinancialsHomeController.index.url}"
+      s"${appConfig.financialsFrontendUrl}${controllers.routes.YourContactDetailsController.onPageLoad()}"
 
     for {
       email <- dataStoreService.getEmail(request.user.eori).flatMap {

--- a/app/controllers/YourContactDetailsController.scala
+++ b/app/controllers/YourContactDetailsController.scala
@@ -85,7 +85,7 @@ class YourContactDetailsController @Inject()(authenticate: IdentifierAction,
       companyName <- dataStoreService.getOwnCompanyName(request.user.eori)
       dataStoreAddress <- dataStoreService.getCompanyAddress(request.user.eori)
       companyAddress =
-        dataStoreAddress.getOrElse(new CompanyAddress(emptyString, emptyString, Some(emptyString), emptyString))
+        dataStoreAddress.getOrElse(CompanyAddress(emptyString, emptyString, Some(emptyString), emptyString))
 
       address = CompanyAddress(
         streetAndNumber = companyAddress.streetAndNumber,
@@ -93,10 +93,15 @@ class YourContactDetailsController @Inject()(authenticate: IdentifierAction,
         postalCode = companyAddress.postalCode,
         countryCode = companyAddress.countryCode)
 
-      accountlinks <- sessionCacheConnector.getAccontLinks(localSessionId.value)
+      accountLinks <- sessionCacheConnector.getAccontLinks(localSessionId.value)
     } yield {
-      Ok(view(request.user.eori, accountlinks.getOrElse(Seq.empty[AccountLinkWithoutDate]),
-        companyName, address, email.toString)(request, messages, appConfig))
+      Ok(
+        view(request.user.eori,
+          accountLinks.getOrElse(Seq.empty[AccountLinkWithoutDate]),
+          companyName,
+          address,
+          email.toString)(request, messages, appConfig)
+      )
     }
   }
 

--- a/app/views/your_contact_details/your_contact_details.scala.html
+++ b/app/views/your_contact_details/your_contact_details.scala.html
@@ -39,7 +39,8 @@
     accountLinks: Seq[AccountLinkWithoutDate],
     companyName: Option[String],
     companyAddress: CompanyAddress,
-    email: String
+    email: String,
+    messageBannerPartial: Option[HtmlFormat.Appendable] = None
 )(
     implicit request: Request[_],
     messages: Messages,
@@ -48,6 +49,7 @@
 
 @layout(
     pageTitle = Some(messages("cf.contact-details.title")),
+    maybeMessageBannerPartial = messageBannerPartial,
     helpAndSupport = false,
     backLink = Some(routes.CustomsFinancialsHomeController.index.url)
 ) {

--- a/test/controllers/YourContactDetailsControllerSpec.scala
+++ b/test/controllers/YourContactDetailsControllerSpec.scala
@@ -16,7 +16,7 @@
 
 package controllers
 
-import connectors.{CustomsFinancialsSessionCacheConnector, SdesConnector}
+import connectors.{CustomsFinancialsSessionCacheConnector, SdesConnector, SecureMessageConnector}
 import domain.*
 import org.mockito.ArgumentMatchers
 import org.mockito.ArgumentMatchers.any
@@ -29,6 +29,8 @@ import services.{ApiService, DataStoreService}
 import uk.gov.hmrc.auth.core.retrieve.Email
 import uk.gov.hmrc.http.{HeaderCarrier, HttpReads, HttpResponse}
 import uk.gov.hmrc.http.client.{HttpClientV2, RequestBuilder}
+import uk.gov.hmrc.play.partials.HtmlPartial
+import utils.TestData.TEST_ID
 
 import scala.concurrent.{ExecutionContext, Future}
 import java.net.URL
@@ -48,12 +50,40 @@ class YourContactDetailsControllerSpec extends SpecBase with ShouldMatchers{
       when(mockSessionCache.getSessionId(any[String])(any[HeaderCarrier])).thenReturn(Future.successful(
         Option(HttpResponse(OK, sessionValue))))
 
+      when(mockSecureMessageConnector.getMessageCountBanner(any)(any))
+        .thenReturn(Future.successful(Some(HtmlPartial.Success(Some(TEST_ID), createHtmlContentForBanner()))))
+
       val request: FakeRequest[AnyContentAsEmpty.type] = fakeRequestWithSession(GET,
         routes.YourContactDetailsController.onPageLoad().url,
         sessionValue)
 
       val result: Future[Result] = route(app, request).value
       status(result) should be(OK)
+    }
+
+    "display the message banner on successful page load" in new Setup {
+      val sessionValue = "session_acfe456"
+
+      when(requestBuilder.execute(any[HttpReads[String]], any[ExecutionContext]))
+        .thenReturn(Future.successful("Some_String"))
+
+      when(mockHttpClient.get(any[URL]())(any())).thenReturn(requestBuilder)
+
+      when(mockSessionCache.getSessionId(any[String])(any[HeaderCarrier])).thenReturn(Future.successful(
+        Option(HttpResponse(OK, sessionValue))))
+
+      when(mockSecureMessageConnector.getMessageCountBanner(any)(any))
+        .thenReturn(Future.successful(Some(HtmlPartial.Success(Some(TEST_ID), createHtmlContentForBanner()))))
+
+      val request: FakeRequest[AnyContentAsEmpty.type] = fakeRequestWithSession(GET,
+        routes.YourContactDetailsController.onPageLoad().url,
+        sessionValue)
+
+      val result: Future[Result] = route(app, request).value
+      status(result) should be(OK)
+
+      val viewContent: String = contentAsString(result)
+      shouldDisplayMessageBanner(viewContent)
     }
 
     "redirect to Home page if cache session id and request session id do not match" in new Setup {
@@ -116,6 +146,32 @@ class YourContactDetailsControllerSpec extends SpecBase with ShouldMatchers{
     }
   }
 
+  private def shouldDisplayMessageBanner(view: String) = {
+    view should include("Home")
+    view should include("Messages")
+    view should include("Your contact details")
+    view should include("Your account authorities")
+  }
+
+  private def createHtmlContentForBanner() = {
+    import play.twirl.api.Html
+
+    Html("""<html>
+           | <head></head>
+           | <body>
+           |  <div class="govuk-!-padding-bottom-3 govuk-!-padding-top-3 notifications-bar">
+           |   <ul class="govuk-list">
+           |    <li><a class="govuk-link" href="http://localhost:9876/customs/payment-records">Home</a></li>
+           |    <li class="notifications-bar-ul-li"><a class="govuk-link" href="http://localhost:9842/customs/secure-messaging/inbox?return_to=test_url"> Messages<span class="hmrc-notification-badge">2</span> </a></li>
+           |    <li><a class="govuk-link" href="http://localhost:9876/customs/payment-records/your-contact-details">Your contact details</a></li>
+           |    <li><a class="govuk-link" href="http://localhost:9000/customs/manage-authorities">Your account authorities</a></li>
+           |   </ul>
+           |  </div>
+           |  <hr class="govuk-section-break govuk-section-break--visible" aria-hidden="true">
+           | </body>
+           |</html>""".stripMargin)
+  }
+
   trait Setup {
 
     val n1 = 200
@@ -157,6 +213,7 @@ class YourContactDetailsControllerSpec extends SpecBase with ShouldMatchers{
     val mockApiService: ApiService = mock[ApiService]
     val mockDataStoreService: DataStoreService = mock[DataStoreService]
     val mockSdesConnector: SdesConnector = mock[SdesConnector]
+    val mockSecureMessageConnector: SecureMessageConnector = mock[SecureMessageConnector]
     val mockSessionCache: CustomsFinancialsSessionCacheConnector = mock[CustomsFinancialsSessionCacheConnector]
     val mockHttpClient: HttpClientV2 = mock[HttpClientV2]
     val requestBuilder: RequestBuilder = mock[RequestBuilder]
@@ -175,6 +232,7 @@ class YourContactDetailsControllerSpec extends SpecBase with ShouldMatchers{
         inject.bind[ApiService].toInstance(mockApiService),
         inject.bind[DataStoreService].toInstance(mockDataStoreService),
         inject.bind[SdesConnector].toInstance(mockSdesConnector),
+        inject.bind[SecureMessageConnector].toInstance(mockSecureMessageConnector),
         inject.bind[CustomsFinancialsSessionCacheConnector].toInstance(mockSessionCache)
       ).configure("features.new-agent-view-enabled" -> false).build()
   }

--- a/test/controllers/YourContactDetailsControllerSpec.scala
+++ b/test/controllers/YourContactDetailsControllerSpec.scala
@@ -49,8 +49,7 @@ class YourContactDetailsControllerSpec extends SpecBase with ShouldMatchers {
       when(mockSessionCache.getSessionId(any[String])(any[HeaderCarrier])).thenReturn(Future.successful(
         Option(HttpResponse(OK, sessionId))))
 
-      when(mockSecureMessageConnector.getMessageCountBanner(any)(any))
-        .thenReturn(Future.successful(Some(HtmlPartial.Success(Some(TEST_ID), TEST_MESSAGE_BANNER))))
+      when(mockSecureMessageConnector.getMessageCountBanner(any)(any)).thenReturn(Future.successful(None))
 
       val request: FakeRequest[AnyContentAsEmpty.type] = fakeRequestWithSession(GET,
         routes.YourContactDetailsController.onPageLoad().url,

--- a/test/controllers/YourContactDetailsControllerSpec.scala
+++ b/test/controllers/YourContactDetailsControllerSpec.scala
@@ -19,7 +19,7 @@ package controllers
 import connectors.{CustomsFinancialsSessionCacheConnector, SdesConnector, SecureMessageConnector}
 import domain.*
 import org.mockito.ArgumentMatchers
-import org.mockito.ArgumentMatchers.any
+import org.mockito.ArgumentMatchers.{any, eq => eqTo}
 import org.mockito.Mockito.when
 import play.api.mvc.{AnyContentAsEmpty, Result}
 import play.api.test.FakeRequest
@@ -63,6 +63,7 @@ class YourContactDetailsControllerSpec extends SpecBase with ShouldMatchers{
 
     "display the message banner on successful page load" in new Setup {
       val sessionValue = "session_acfe456"
+      val returnUrl = s"http://localhost:9876${controllers.routes.YourContactDetailsController.onPageLoad()}"
 
       when(requestBuilder.execute(any[HttpReads[String]], any[ExecutionContext]))
         .thenReturn(Future.successful("Some_String"))
@@ -72,7 +73,7 @@ class YourContactDetailsControllerSpec extends SpecBase with ShouldMatchers{
       when(mockSessionCache.getSessionId(any[String])(any[HeaderCarrier])).thenReturn(Future.successful(
         Option(HttpResponse(OK, sessionValue))))
 
-      when(mockSecureMessageConnector.getMessageCountBanner(any)(any))
+      when(mockSecureMessageConnector.getMessageCountBanner(eqTo(returnUrl))(any))
         .thenReturn(Future.successful(Some(HtmlPartial.Success(Some(TEST_ID), createHtmlContentForBanner()))))
 
       val request: FakeRequest[AnyContentAsEmpty.type] = fakeRequestWithSession(GET,

--- a/test/controllers/YourContactDetailsControllerSpec.scala
+++ b/test/controllers/YourContactDetailsControllerSpec.scala
@@ -40,7 +40,6 @@ class YourContactDetailsControllerSpec extends SpecBase with ShouldMatchers {
 
   "YourContactDetailsController" should {
     "return OK when request session id is found in the cache" in new Setup {
-      val sessionValue = "session_acfe456"
 
       when(requestBuilder.execute(any[HttpReads[String]], any[ExecutionContext]))
         .thenReturn(Future.successful("Some_String"))
@@ -48,21 +47,20 @@ class YourContactDetailsControllerSpec extends SpecBase with ShouldMatchers {
       when(mockHttpClient.get(any[URL]())(any())).thenReturn(requestBuilder)
 
       when(mockSessionCache.getSessionId(any[String])(any[HeaderCarrier])).thenReturn(Future.successful(
-        Option(HttpResponse(OK, sessionValue))))
+        Option(HttpResponse(OK, sessionId))))
 
       when(mockSecureMessageConnector.getMessageCountBanner(any)(any))
         .thenReturn(Future.successful(Some(HtmlPartial.Success(Some(TEST_ID), TEST_MESSAGE_BANNER))))
 
       val request: FakeRequest[AnyContentAsEmpty.type] = fakeRequestWithSession(GET,
         routes.YourContactDetailsController.onPageLoad().url,
-        sessionValue)
+        sessionId)
 
       val result: Future[Result] = route(app, request).value
       status(result) should be(OK)
     }
 
     "display the message banner on successful page load" in new Setup {
-      val sessionValue = "session_acfe456"
       val returnUrl = s"http://localhost:9876${controllers.routes.YourContactDetailsController.onPageLoad()}"
 
       when(requestBuilder.execute(any[HttpReads[String]], any[ExecutionContext]))
@@ -71,14 +69,14 @@ class YourContactDetailsControllerSpec extends SpecBase with ShouldMatchers {
       when(mockHttpClient.get(any[URL]())(any())).thenReturn(requestBuilder)
 
       when(mockSessionCache.getSessionId(any[String])(any[HeaderCarrier])).thenReturn(Future.successful(
-        Option(HttpResponse(OK, sessionValue))))
+        Option(HttpResponse(OK, sessionId))))
 
       when(mockSecureMessageConnector.getMessageCountBanner(eqTo(returnUrl))(any))
         .thenReturn(Future.successful(Some(HtmlPartial.Success(Some(TEST_ID), TEST_MESSAGE_BANNER))))
 
       val request: FakeRequest[AnyContentAsEmpty.type] = fakeRequestWithSession(GET,
         routes.YourContactDetailsController.onPageLoad().url,
-        sessionValue)
+        sessionId)
 
       val result: Future[Result] = route(app, request).value
       status(result) should be(OK)
@@ -88,7 +86,6 @@ class YourContactDetailsControllerSpec extends SpecBase with ShouldMatchers {
     }
 
     "redirect to Home page if cache session id and request session id do not match" in new Setup {
-      val sessionCacheValue = "session_acfe456"
       val sessionHeaderValue = "session_acf"
 
       when(requestBuilder.execute(any[HttpReads[String]], any[ExecutionContext]))
@@ -97,7 +94,7 @@ class YourContactDetailsControllerSpec extends SpecBase with ShouldMatchers {
       when(mockHttpClient.get(any[URL]())(any())).thenReturn(requestBuilder)
 
       when(mockSessionCache.getSessionId(any[String])(any[HeaderCarrier])).thenReturn(Future.successful(
-        Option(HttpResponse(OK, sessionCacheValue))))
+        Option(HttpResponse(OK, sessionId))))
 
       val request: FakeRequest[AnyContentAsEmpty.type] = fakeRequestWithSession(GET,
         routes.YourContactDetailsController.onPageLoad().url,
@@ -155,6 +152,7 @@ class YourContactDetailsControllerSpec extends SpecBase with ShouldMatchers {
   }
 
   trait Setup {
+    val sessionId = "session_acfe456"
 
     val n1 = 200
     val n2 = 100

--- a/test/controllers/YourContactDetailsControllerSpec.scala
+++ b/test/controllers/YourContactDetailsControllerSpec.scala
@@ -30,20 +30,20 @@ import uk.gov.hmrc.auth.core.retrieve.Email
 import uk.gov.hmrc.http.{HeaderCarrier, HttpReads, HttpResponse}
 import uk.gov.hmrc.http.client.{HttpClientV2, RequestBuilder}
 import uk.gov.hmrc.play.partials.HtmlPartial
-import utils.TestData.TEST_ID
+import utils.TestData.{TEST_ID, TEST_MESSAGE_BANNER}
 
 import scala.concurrent.{ExecutionContext, Future}
 import java.net.URL
 import utils.{ShouldMatchers, SpecBase}
 
-class YourContactDetailsControllerSpec extends SpecBase with ShouldMatchers{
+class YourContactDetailsControllerSpec extends SpecBase with ShouldMatchers {
 
   "YourContactDetailsController" should {
     "return OK when request session id is found in the cache" in new Setup {
       val sessionValue = "session_acfe456"
 
       when(requestBuilder.execute(any[HttpReads[String]], any[ExecutionContext]))
-      .thenReturn(Future.successful("Some_String"))
+        .thenReturn(Future.successful("Some_String"))
 
       when(mockHttpClient.get(any[URL]())(any())).thenReturn(requestBuilder)
 
@@ -51,7 +51,7 @@ class YourContactDetailsControllerSpec extends SpecBase with ShouldMatchers{
         Option(HttpResponse(OK, sessionValue))))
 
       when(mockSecureMessageConnector.getMessageCountBanner(any)(any))
-        .thenReturn(Future.successful(Some(HtmlPartial.Success(Some(TEST_ID), createHtmlContentForBanner()))))
+        .thenReturn(Future.successful(Some(HtmlPartial.Success(Some(TEST_ID), TEST_MESSAGE_BANNER))))
 
       val request: FakeRequest[AnyContentAsEmpty.type] = fakeRequestWithSession(GET,
         routes.YourContactDetailsController.onPageLoad().url,
@@ -74,7 +74,7 @@ class YourContactDetailsControllerSpec extends SpecBase with ShouldMatchers{
         Option(HttpResponse(OK, sessionValue))))
 
       when(mockSecureMessageConnector.getMessageCountBanner(eqTo(returnUrl))(any))
-        .thenReturn(Future.successful(Some(HtmlPartial.Success(Some(TEST_ID), createHtmlContentForBanner()))))
+        .thenReturn(Future.successful(Some(HtmlPartial.Success(Some(TEST_ID), TEST_MESSAGE_BANNER))))
 
       val request: FakeRequest[AnyContentAsEmpty.type] = fakeRequestWithSession(GET,
         routes.YourContactDetailsController.onPageLoad().url,
@@ -152,25 +152,6 @@ class YourContactDetailsControllerSpec extends SpecBase with ShouldMatchers{
     view should include("Messages")
     view should include("Your contact details")
     view should include("Your account authorities")
-  }
-
-  private def createHtmlContentForBanner() = {
-    import play.twirl.api.Html
-
-    Html("""<html>
-           | <head></head>
-           | <body>
-           |  <div class="govuk-!-padding-bottom-3 govuk-!-padding-top-3 notifications-bar">
-           |   <ul class="govuk-list">
-           |    <li><a class="govuk-link" href="http://localhost:9876/customs/payment-records">Home</a></li>
-           |    <li class="notifications-bar-ul-li"><a class="govuk-link" href="http://localhost:9842/customs/secure-messaging/inbox?return_to=test_url"> Messages<span class="hmrc-notification-badge">2</span> </a></li>
-           |    <li><a class="govuk-link" href="http://localhost:9876/customs/payment-records/your-contact-details">Your contact details</a></li>
-           |    <li><a class="govuk-link" href="http://localhost:9000/customs/manage-authorities">Your account authorities</a></li>
-           |   </ul>
-           |  </div>
-           |  <hr class="govuk-section-break govuk-section-break--visible" aria-hidden="true">
-           | </body>
-           |</html>""".stripMargin)
   }
 
   trait Setup {

--- a/test/utils/TestData.scala
+++ b/test/utils/TestData.scala
@@ -16,6 +16,8 @@
 
 package utils
 
+import play.twirl.api.Html
+
 object TestData {
 
   val TEST_ID = "test_id"
@@ -107,4 +109,32 @@ object TestData {
   val LENGTH_27 = 27
 
   val TEST_EORI = "GB12345678"
+
+  lazy val TEST_MESSAGE_BANNER: Html = Html(
+    """<html>
+      | <head></head>
+      | <body>
+      |  <div class="govuk-!-padding-bottom-3 govuk-!-padding-top-3 notifications-bar">
+      |   <ul class="govuk-list">
+      |    <li><a class="govuk-link" href="http://localhost:9876/customs/payment-records">Home</a></li>
+      |    <li class="notifications-bar-ul-li">
+      |      <a class="govuk-link" href="http://localhost:9842/customs/secure-messaging/inbox?return_to=test_url">
+      |          Messages<span class="hmrc-notification-badge">2</span>
+      |      </a>
+      |   </li>
+      |    <li>
+      |      <a class="govuk-link" href="http://localhost:9876/customs/payment-records/your-contact-details">
+      |        Your contact details
+      |      </a>
+      |    </li>
+      |    <li>
+      |      <a class="govuk-link" href="http://localhost:9000/customs/manage-authorities">
+      |        Your account authorities
+      |      </a>
+      |    </li>
+      |   </ul>
+      |  </div>
+      |  <hr class="govuk-section-break govuk-section-break--visible" aria-hidden="true">
+      | </body>
+      |</html>""".stripMargin)
 }

--- a/test/utils/TestData.scala
+++ b/test/utils/TestData.scala
@@ -18,6 +18,7 @@ package utils
 
 object TestData {
 
+  val TEST_ID = "test_id"
   val ITEMS_20 = 20
   val ITEMS_40 = 40
   val ITEMS_45 = 45
@@ -85,7 +86,7 @@ object TestData {
   val DAY_20 = 20
   val DAY_25 = 25
 
-  val HOUR_12= 12
+  val HOUR_12 = 12
   val MINUTES_30 = 30
 
   val FILE_SIZE_DEFAULT = 1234L

--- a/test/views/your_contact_details/YourContactDetailsViewSpec.scala
+++ b/test/views/your_contact_details/YourContactDetailsViewSpec.scala
@@ -14,21 +14,20 @@
  * limitations under the License.
  */
 
-package views
+package views.your_contact_details
 
 import config.AppConfig
 import domain.{AccountLinkWithoutDate, CompanyAddress}
 import org.jsoup.Jsoup
 import org.jsoup.nodes.Document
-
+import org.jsoup.select.Elements
 import play.api.Application
 import play.api.i18n.{I18nSupport, MessagesApi}
 import play.api.mvc.AnyContentAsEmpty
 import play.api.test.FakeRequest
-import play.api.test.Helpers._
-import utils.SpecBase
+import play.api.test.Helpers.*
+import utils.{MustMatchers, SpecBase}
 import views.html.your_contact_details.your_contact_details
-import utils.MustMatchers
 
 class YourContactDetailsViewSpec extends SpecBase with MustMatchers {
 
@@ -71,6 +70,27 @@ class YourContactDetailsViewSpec extends SpecBase with MustMatchers {
           "This is the contact address you gave us when you registered for your EORI number." +
             " You can fill in an enquiry form (opens in a new tab) to change this address."
       }
+    }
+
+    "display the message banner" in new Setup {
+      val bannerComponent: Elements = view.getElementsByClass("govuk-!-padding-top-3 notifications-bar")
+      bannerComponent.size() must be > 0
+    }
+
+    "displays home as a link text and contain the correct url" in new Setup {
+      assert(view.containsLinkWithText("#", "Home"))
+    }
+
+    "displays Messages as a link text in message banner" in new Setup {
+      assert(view.containsLinkWithText("#", "Messages"))
+    }
+
+    "displays Your contact details as a link text in message banner" in new Setup {
+      assert(view.containsLinkWithText("#", "Your contact details"))
+    }
+
+    "displays Your account authorities as a link text in message banner" in new Setup {
+      assert(view.containsLinkWithText("#", "Your account authorities"))
     }
   }
 

--- a/test/views/your_contact_details/YourContactDetailsViewSpec.scala
+++ b/test/views/your_contact_details/YourContactDetailsViewSpec.scala
@@ -74,16 +74,19 @@ class YourContactDetailsViewSpec extends SpecBase with MustMatchers {
       }
     }
 
-    "display the message banner when provided" in new Setup {
+    "display the message banner partial when provided" in new Setup {
       val pageView: Document = view(Some(HtmlFormat.fill(Seq(TEST_MESSAGE_BANNER))))
-      val bannerComponent: Elements = pageView.getElementsByClass("govuk-!-padding-top-3 notifications-bar")
+      val bannerComponent: Elements = pageView.getElementsByClass("notifications-bar")
 
       bannerComponent.size() must be > 0
 
-      assert(pageView.containsLinkWithText("#", "Home"))
-      assert(pageView.containsLinkWithText("#", "Messages"))
-      assert(pageView.containsLinkWithText("#", "Your contact details"))
-      assert(pageView.containsLinkWithText("#", "Your account authorities"))
+      assert(pageView.containsLinkWithText("http://localhost:9876/customs/payment-records", "Home"))
+      assert(pageView.containsLink("http://localhost:9842/customs/secure-messaging/inbox?return_to=test_url"))
+
+      assert(pageView.containsLinkWithText(
+        "http://localhost:9876/customs/payment-records/your-contact-details", "Your contact details"))
+      assert(pageView.containsLinkWithText(
+        "http://localhost:9000/customs/manage-authorities", "Your account authorities"))
     }
   }
 

--- a/test/views/your_contact_details/YourContactDetailsViewSpec.scala
+++ b/test/views/your_contact_details/YourContactDetailsViewSpec.scala
@@ -42,7 +42,7 @@ class YourContactDetailsViewSpec extends SpecBase with MustMatchers {
       running(app) {
         view.getElementsByTag("h2").text mustBe "Help make GOV.UK better " +
           "Company details Primary email address Duty deferment contact details Support links"
-        }
+      }
     }
 
     "display the govlink" in new Setup {
@@ -77,19 +77,19 @@ class YourContactDetailsViewSpec extends SpecBase with MustMatchers {
       bannerComponent.size() must be > 0
     }
 
-    "displays home as a link text and contain the correct url" in new Setup {
+    "display 'Home' as a link text and contain the correct url" in new Setup {
       assert(view.containsLinkWithText("#", "Home"))
     }
 
-    "displays Messages as a link text in message banner" in new Setup {
+    "display 'Messages' as a link text in message banner" in new Setup {
       assert(view.containsLinkWithText("#", "Messages"))
     }
 
-    "displays Your contact details as a link text in message banner" in new Setup {
+    "display 'Your contact details' as a link text in message banner" in new Setup {
       assert(view.containsLinkWithText("#", "Your contact details"))
     }
 
-    "displays Your account authorities as a link text in message banner" in new Setup {
+    "display 'Your account authorities' as a link text in message banner" in new Setup {
       assert(view.containsLinkWithText("#", "Your account authorities"))
     }
   }

--- a/test/views/your_contact_details/YourContactDetailsViewSpec.scala
+++ b/test/views/your_contact_details/YourContactDetailsViewSpec.scala
@@ -28,69 +28,62 @@ import play.api.test.FakeRequest
 import play.api.test.Helpers.*
 import utils.{MustMatchers, SpecBase}
 import views.html.your_contact_details.your_contact_details
+import play.twirl.api.HtmlFormat
+import utils.TestData.TEST_MESSAGE_BANNER
 
 class YourContactDetailsViewSpec extends SpecBase with MustMatchers {
 
   "Customs Financials Your Contact Details" should {
     "display header" in new Setup {
       running(app) {
-        view.getElementsByTag("h1").text mustBe "Your contact details"
+        view().getElementsByTag("h1").text mustBe "Your contact details"
       }
     }
 
     "display second header text" in new Setup {
       running(app) {
-        view.getElementsByTag("h2").text mustBe "Help make GOV.UK better " +
+        view().getElementsByTag("h2").text mustBe "Help make GOV.UK better " +
           "Company details Primary email address Duty deferment contact details Support links"
       }
     }
 
     "display the govlink" in new Setup {
       running(app) {
-        view.getElementsByClass("govuk-link")
+        view().getElementsByClass("govuk-link")
       }
     }
 
     "display link to view or change" in new Setup {
       running(app) {
-        view.containsLinkWithText("#", "View or change")
+        view().containsLinkWithText("#", "View or change")
       }
     }
 
     "display link to report a change" in new Setup {
       running(app) {
-        view.containsLinkWithText(appConfig.reportChangeCdsUrl,
+        view().containsLinkWithText(appConfig.reportChangeCdsUrl,
           "Report a change to your company details (opens in new tab)")
       }
     }
 
     "display link to get enquiry form for your contact details" in new Setup {
       running(app) {
-        view.getElementById("contact-report-change-link").text() mustBe
+        view().getElementById("contact-report-change-link").text() mustBe
           "This is the contact address you gave us when you registered for your EORI number." +
             " You can fill in an enquiry form (opens in a new tab) to change this address."
       }
     }
 
-    "display the message banner" in new Setup {
-      val bannerComponent: Elements = view.getElementsByClass("govuk-!-padding-top-3 notifications-bar")
+    "display the message banner when provided" in new Setup {
+      val pageView: Document = view(Some(HtmlFormat.fill(Seq(TEST_MESSAGE_BANNER))))
+      val bannerComponent: Elements = pageView.getElementsByClass("govuk-!-padding-top-3 notifications-bar")
+
       bannerComponent.size() must be > 0
-    }
 
-    "display 'Home' as a link text and contain the correct url" in new Setup {
-      assert(view.containsLinkWithText("#", "Home"))
-    }
-
-    "display 'Messages' as a link text in message banner" in new Setup {
-      assert(view.containsLinkWithText("#", "Messages"))
-    }
-
-    "display 'Your contact details' as a link text in message banner" in new Setup {
-      assert(view.containsLinkWithText("#", "Your contact details"))
-    }
-
-    "display 'Your account authorities' as a link text in message banner" in new Setup {
-      assert(view.containsLinkWithText("#", "Your account authorities"))
+      assert(pageView.containsLinkWithText("#", "Home"))
+      assert(pageView.containsLinkWithText("#", "Messages"))
+      assert(pageView.containsLinkWithText("#", "Your contact details"))
+      assert(pageView.containsLinkWithText("#", "Your account authorities"))
     }
   }
 
@@ -115,8 +108,14 @@ class YourContactDetailsViewSpec extends SpecBase with MustMatchers {
     val app: Application = application().build()
     implicit val appConfig: AppConfig = app.injector.instanceOf[AppConfig]
 
-    def view: Document = Jsoup.parse(app.injector.instanceOf[your_contact_details].apply(
-      eori, accountNumbers, companyName, companyAddress, email).body)
+    def view(messageBannerPartial: Option[HtmlFormat.Appendable] = None): Document =
+      Jsoup.parse(app.injector.instanceOf[your_contact_details].apply(
+        eori,
+        accountNumbers,
+        companyName,
+        companyAddress,
+        email,
+        messageBannerPartial).body)
 
     override def messagesApi: MessagesApi = app.injector.instanceOf[MessagesApi]
   }


### PR DESCRIPTION
Description - Code changes to implement the message banner as header for 'Your Contact Details Page'

Below have been done as part of this PR

- [x] add tests and update the existing tests
- [x] add relevant code changes to pull message banner from Secure messaging frontend
- [x] minor refactoring
- [x] add a new val named TEST_MESSAGE_BANNER in Test Data