### PR TITLE
MMCA-5008 | Back hyperlink from 'Find accounts you have authority to use' page should navigate to previous page

### DIFF
--- a/app/views/authorised_to_view/authorised_to_view_search.scala.html
+++ b/app/views/authorised_to_view/authorised_to_view_search.scala.html
@@ -44,7 +44,7 @@
 @layout(
     pageTitle = Some(title(form, "cf.search.authorities", None, Seq())),
     helpAndSupport = false, 
-    backLink = Some(routes.CustomsFinancialsHomeController.index.url)
+    backLink = Some(appConfig.manageAuthoritiesFrontendUrl)
 ){
 
     @formHelper(action = controllers.routes.AuthorizedToViewController.onSubmit()) {

--- a/test/views/authorised_to_view/AuthorisedToViewSearchSpec.scala
+++ b/test/views/authorised_to_view/AuthorisedToViewSearchSpec.scala
@@ -152,6 +152,12 @@ class AuthorisedToViewSearchSpec extends SpecBase with MustMatchers {
         messages(app)("cf.authorities.notification-panel.a.xi-authority")
       view.getElementById("xi-csv-authority-link").attr("href") mustBe xiAuthUrl
     }
+
+    "have a correct back link to manage authorities page" in new SetUp {
+      val backLink: Elements = sampleView.select("a.govuk-back-link")
+
+      backLink.attr("href") mustBe appConfig.manageAuthoritiesFrontendUrl
+    }
   }
 
   trait SetUp {
@@ -162,5 +168,14 @@ class AuthorisedToViewSearchSpec extends SpecBase with MustMatchers {
 
     val form: Form[String] = new EoriNumberFormProvider().apply()
     val date = "SomeDate"
+
+    val authorisedToViewInstance: authorised_to_view_search = app.injector.instanceOf[authorised_to_view_search]
+
+    val sampleView: Document = Jsoup.parse(authorisedToViewInstance.apply(
+        form = form,
+        date = date,
+        fileExists = true,
+        isXiEoriEnabled = true)
+      .body)
   }
 }


### PR DESCRIPTION
**Acceptance criteria:**
**Given** a user is on the 'Find accounts you have authority to use' page
**When** the user clicks on the 'Back' hyperlink
**Then** the user should be navigated back to the 'Manage your account authorities' page

**Dev Tasks:**
- [x] Back hyperlink navigate to the previous page - Manage your account authorities - /customs/manage-authorities/manage-account-authorities
- [x] Add/Amend test cases