### PR TITLE
MMCA 5006 | In-service notifications when multiple cash account transactions are available

### DIFF
--- a/app/domain/SdesFile.scala
+++ b/app/domain/SdesFile.scala
@@ -143,7 +143,7 @@ object FileRole {
 
   case object CDSCashAccount extends FileRole(
     "CDSCashAccount", "cash-statement",
-    "Display Cash Statements", "cash-statement"
+    "Display Cash Statements", "requested-cash-statement"
   )
 
   val log: LoggerLike = Logger(this.getClass)

--- a/app/domain/SdesFile.scala
+++ b/app/domain/SdesFile.scala
@@ -143,7 +143,7 @@ object FileRole {
 
   case object CDSCashAccount extends FileRole(
     "CDSCashAccount", "cash-statement",
-    "Display Cash Statements", "requested-cash-statement"
+    "Display Cash Statements", "cash-statement"
   )
 
   val log: LoggerLike = Logger(this.getClass)

--- a/conf/messages.cy
+++ b/conf/messages.cy
@@ -263,7 +263,7 @@ cf.customs-financials-home.notification.multiple-duty-deferment = Mae gennych dd
 cf.customs-financials-home.notification.multiple-c79 = Mae gennych dystysgrifau TAW mewnforio (C79) newydd
 cf.customs-financials-home.notification.multiple-postponed-vat = Mae gennych ddatganiadau TAW mewnforio gohiriedig newydd
 cf.customs-financials-home.notification.multiple-adjustments = 	Mae gennych ddatganiadau addasiadau mewnforio newydd
-cf.customs-financials-home.notification.multiple-requested-cash-statement=Mae’r trafodion cyfrif arian parod y gwnaethoch gais amdanynt yn barod i’w gweld
+cf.customs-financials-home.notification.multiple-requested-cash-statement=Mae’r trafodion cyfrif arian parod y gwnaethoch gais amdanynt yn barod i’w gweld.
 
 cf.account.manage-account-authorities.title=Rheoli awdurdodau eich cyfrif
 

--- a/conf/messages.cy
+++ b/conf/messages.cy
@@ -263,6 +263,7 @@ cf.customs-financials-home.notification.multiple-duty-deferment = Mae gennych dd
 cf.customs-financials-home.notification.multiple-c79 = Mae gennych dystysgrifau TAW mewnforio (C79) newydd
 cf.customs-financials-home.notification.multiple-postponed-vat = Mae gennych ddatganiadau TAW mewnforio gohiriedig newydd
 cf.customs-financials-home.notification.multiple-adjustments = 	Mae gennych ddatganiadau addasiadau mewnforio newydd
+cf.customs-financials-home.notification.multiple-requested-cash-statement=Mae’r trafodion cyfrif arian parod y gwnaethoch gais amdanynt yn barod i’w gweld
 
 cf.account.manage-account-authorities.title=Rheoli awdurdodau eich cyfrif
 

--- a/conf/messages.en
+++ b/conf/messages.en
@@ -166,7 +166,7 @@ cf.customs-financials-home.notification.requested-c79=Your requested import VAT 
 cf.customs-financials-home.notification.requested-duty-deferment=Your requested duty deferment statements are available to view
 cf.customs-financials-home.notification.requested-adjustments=Your requested import adjustments statements are available to view
 cf.customs-financials-home.notification.requested-postponed-vat=Your requested postponed import VAT statements are available to view
-cf.customs-financials-home.notification.requested-cash-statement=Your requested cash account transactions are available to view.
+cf.customs-financials-home.notification.requested-cash-statement=Your requested cash account transactions are available to view
 cf.customs-financials-home.notification.authorities=Your requested list of accounts you have authority to use is available
 
 # Verify Your Email Address
@@ -332,6 +332,7 @@ cf.customs-financials-home.notification.multiple-duty-deferment = You have new d
 cf.customs-financials-home.notification.multiple-c79 = You have new import VAT certificates (C79)
 cf.customs-financials-home.notification.multiple-postponed-vat = You have new postponed import VAT statements
 cf.customs-financials-home.notification.multiple-adjustments = You have new import adjustment statements
+cf.customs-financials-home.notification.multiple-requested-cash-statement=Your requested cash account transactions are available to view
 cf.account.manage-account-authorities.title=Manage your account authorities
 
 # Timeout Messages

--- a/conf/messages.en
+++ b/conf/messages.en
@@ -166,7 +166,7 @@ cf.customs-financials-home.notification.requested-c79=Your requested import VAT 
 cf.customs-financials-home.notification.requested-duty-deferment=Your requested duty deferment statements are available to view
 cf.customs-financials-home.notification.requested-adjustments=Your requested import adjustments statements are available to view
 cf.customs-financials-home.notification.requested-postponed-vat=Your requested postponed import VAT statements are available to view
-cf.customs-financials-home.notification.requested-cash-statement=Your requested cash account transactions are available to view
+cf.customs-financials-home.notification.requested-cash-statement=Your requested cash account transactions are available to view.
 cf.customs-financials-home.notification.authorities=Your requested list of accounts you have authority to use is available
 
 # Verify Your Email Address
@@ -332,7 +332,7 @@ cf.customs-financials-home.notification.multiple-duty-deferment = You have new d
 cf.customs-financials-home.notification.multiple-c79 = You have new import VAT certificates (C79)
 cf.customs-financials-home.notification.multiple-postponed-vat = You have new postponed import VAT statements
 cf.customs-financials-home.notification.multiple-adjustments = You have new import adjustment statements
-cf.customs-financials-home.notification.multiple-requested-cash-statement=Your requested cash account transactions are available to view
+cf.customs-financials-home.notification.multiple-requested-cash-statement=Your requested cash account transactions are available to view.
 cf.account.manage-account-authorities.title=Manage your account authorities
 
 # Timeout Messages

--- a/test/controllers/HomeControllerSpec.scala
+++ b/test/controllers/HomeControllerSpec.scala
@@ -234,7 +234,7 @@ class HomeControllerSpec extends SpecBase with MustMatchers {
     }
   }
   
-  "show notifications guidance when multiple notifications for cash account" in new Setup {
+  "show notifications guidance when there are multiple notifications for cash account" in new Setup {
     val notifications: List[Notification] = List(
       Notification(CDSCashAccount, isRequested = true),
       Notification(CDSCashAccount, isRequested = true),

--- a/test/controllers/HomeControllerSpec.scala
+++ b/test/controllers/HomeControllerSpec.scala
@@ -250,8 +250,6 @@ class HomeControllerSpec extends SpecBase with MustMatchers {
       val html = Jsoup.parse(contentAsString(result))
       
       html.containsElementById("notification-panel")
-      html.select("#notification-panel")
-        .text() must include("Your requested cash account transactions are available to view")
     }
   }
  

--- a/test/controllers/HomeControllerSpec.scala
+++ b/test/controllers/HomeControllerSpec.scala
@@ -233,26 +233,26 @@ class HomeControllerSpec extends SpecBase with MustMatchers {
       html.containsElementById("notification-panel")
     }
   }
-  
+
   "show notifications guidance when there are multiple notifications for cash account" in new Setup {
     val notifications: List[Notification] = List(
       Notification(CDSCashAccount, isRequested = true),
       Notification(CDSCashAccount, isRequested = true),
       Notification(CDSCashAccount, isRequested = true)
     )
-    
+
     when(mockNotificationService.fetchNotifications(eqTo(eoriNumber))(any)).thenReturn(
       Future.successful(notifications))
-    
+
     running(app) {
       val request = fakeRequest(GET, routes.CustomsFinancialsHomeController.index.url)
       val result = route(app, request).value
       val html = Jsoup.parse(contentAsString(result))
-      
+
       html.containsElementById("notification-panel")
     }
   }
- 
+
   "partial landing page" should {
     "show error message as heading text" in {
 

--- a/test/controllers/HomeControllerSpec.scala
+++ b/test/controllers/HomeControllerSpec.scala
@@ -233,7 +233,28 @@ class HomeControllerSpec extends SpecBase with MustMatchers {
       html.containsElementById("notification-panel")
     }
   }
-
+  
+  "show notifications guidance when multiple notifications for cash account" in new Setup {
+    val notifications: List[Notification] = List(
+      Notification(CDSCashAccount, isRequested = true),
+      Notification(CDSCashAccount, isRequested = true),
+      Notification(CDSCashAccount, isRequested = true)
+    )
+    
+    when(mockNotificationService.fetchNotifications(eqTo(eoriNumber))(any)).thenReturn(
+      Future.successful(notifications))
+    
+    running(app) {
+      val request = fakeRequest(GET, routes.CustomsFinancialsHomeController.index.url)
+      val result = route(app, request).value
+      val html = Jsoup.parse(contentAsString(result))
+      
+      html.containsElementById("notification-panel")
+      html.select("#notification-panel")
+        .text() must include("Your requested cash account transactions are available to view")
+    }
+  }
+ 
   "partial landing page" should {
     "show error message as heading text" in {
 


### PR DESCRIPTION
**Acceptance criteria:**
Ensure the in-service notifications are displayed on MIDVA dashboard when multiple cash account transactions are available 

**Dev Tasks**
- Display correct message for multiple cash account statement notifications on landing page
- Add/Amend test cases 
- Make sure build passes