### PR TITLE
[MMCA-5009] Fixing broken Back navigation

### DIFF
--- a/app/config/ErrorHandler.scala
+++ b/app/config/ErrorHandler.scala
@@ -21,7 +21,7 @@ import play.api.mvc.{Request, RequestHeader}
 import play.twirl.api.Html
 import views.html.error_states.{error_template, not_found_template}
 import uk.gov.hmrc.play.bootstrap.frontend.http.FrontendErrorHandler
-import utils.Utils.emptyString
+import controllers.routes
 
 import javax.inject.{Inject, Singleton}
 import scala.concurrent.{ExecutionContext, Future}
@@ -31,28 +31,35 @@ class ErrorHandler @Inject()(val messagesApi: MessagesApi,
                              implicit val appConfig: AppConfig,
                              notFoundView: not_found_template,
                              errorTemplate: error_template)(protected val ec: ExecutionContext) extends FrontendErrorHandler {
+
   override def standardErrorTemplate(pageTitle: String,
                                      heading: String,
                                      message: String)(implicit requestHeader: RequestHeader): Future[Html] =
     Future.successful(
       errorTemplate(
-        Messages("cf.error.standard-error.title"),
-        Messages("cf.error.standard-error.heading"),
-        Messages("cf.error.standard-error.message"),
-        emptyString,
-        emptyString)
+        pageTitle = Messages("cf.error.standard-error.title"),
+        heading = Messages("cf.error.standard-error.heading"),
+        details = Messages("cf.error.standard-error.message")
+      )
     )
 
   override def notFoundTemplate(implicit requestHeader: RequestHeader): Future[Html] =
     Future.successful(notFoundView())
 
   def unauthorized()(implicit requestHeader: RequestHeader): Html = {
-    errorTemplate(Messages("cf.error.unauthorized.title"), Messages("cf.error.unauthorized.heading"),
-      Messages("cf.error.unauthorized.message"))
+    errorTemplate(
+      pageTitle = Messages("cf.error.unauthorized.title"),
+      heading = Messages("cf.error.unauthorized.heading"),
+      details = Messages("cf.error.unauthorized.message")
+    )
   }
 
   def technicalDifficulties()(implicit requestHeader: RequestHeader): Html = {
-    errorTemplate(Messages("cf.error.technicalDifficulties.title"), Messages("cf.error.technicalDifficulties.heading"),
-      Messages("cf.error.technicalDifficulties.message"))
+    errorTemplate(
+      pageTitle = Messages("cf.error.technicalDifficulties.title"),
+      heading = Messages("cf.error.technicalDifficulties.heading"),
+      backLink = Some(routes.AuthorizedToViewController.onPageLoad().url),
+      details = Messages("cf.error.technicalDifficulties.message")
+    )
   }
 }

--- a/app/views/Layout.scala.html
+++ b/app/views/Layout.scala.html
@@ -105,7 +105,7 @@
                         signOutUrl = Some(controllers.routes.LogoutController.logout.url),
                         accessibilityStatementUrl = Some("/accessibility-statement/customs-financials")
                     ),
-        backLink = Some(BackLink(href = backLink.getOrElse(emptyString))),
+        backLink = backLink.filter(_.nonEmpty).map(BackLink(_)),
         templateOverrides = TemplateOverrides(
                                 additionalHeadBlock = Some(additionalHead),
                                 beforeContentBlock = if (maybeMessageBannerPartial.isDefined || eori.isDefined) Some(beforeContent) else None

--- a/app/views/error_states/error_template.scala.html
+++ b/app/views/error_states/error_template.scala.html
@@ -29,7 +29,11 @@
     details: String*
 )(implicit request:RequestHeader, messages: Messages, appConfig: config.AppConfig)
 
-@layout(pageTitle = Some(pageTitle), helpAndSupport = false) {
+@layout(
+    pageTitle = Some(pageTitle),
+    helpAndSupport = false,
+    backLink = Some(routes.AuthorizedToViewController.onPageLoad().url)
+) {
 
     @h1(heading, classes = "govuk-heading-xl")
 

--- a/app/views/error_states/error_template.scala.html
+++ b/app/views/error_states/error_template.scala.html
@@ -26,13 +26,14 @@
 @(
     pageTitle: String,
     heading: String,
+    backLink: Option[String] = None,
     details: String*
 )(implicit request:RequestHeader, messages: Messages, appConfig: config.AppConfig)
 
 @layout(
     pageTitle = Some(pageTitle),
     helpAndSupport = false,
-    backLink = Some(routes.AuthorizedToViewController.onPageLoad().url)
+    backLink = backLink
 ) {
 
     @h1(heading, classes = "govuk-heading-xl")

--- a/test/views/ErrorTemplateSpec.scala
+++ b/test/views/ErrorTemplateSpec.scala
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package views
+
+import config.AppConfig
+import org.jsoup.Jsoup
+import org.jsoup.nodes.Document
+import play.api.Application
+import play.api.i18n.{I18nSupport, Messages, MessagesApi}
+import play.api.mvc.AnyContentAsEmpty
+import play.api.test.FakeRequest
+import play.api.test.Helpers.running
+import utils.{SpecBase, MustMatchers}
+import views.html.error_states.error_template
+
+class ErrorTemplateSpec extends SpecBase with MustMatchers {
+
+  "ErrorTemplateSpec view" should {
+
+    "display correct information" when {
+
+      "main header is correct" in new Setup {
+        running(app) {
+          view.getElementsByTag("h1").text() mustBe messages(
+            "cf.error.technicalDifficulties.heading"
+          )
+        }
+      }
+
+      "backlink should be visible" in new Setup {
+        running(app) {
+          backLink must not be null
+        }
+      }
+
+      "backlink URL is correct" in new Setup {
+        running(app) {
+          backLink.attr("href") mustBe expectedBackLinkPath
+        }
+      }
+
+      "error message is correct" in new Setup {
+        running(app) {
+          view.getElementsByClass("govuk-body").get(0).text() mustBe messages(
+            "cf.error.technicalDifficulties.message"
+          )
+        }
+      }
+    }
+  }
+
+  trait Setup extends I18nSupport {
+    implicit val request: FakeRequest[AnyContentAsEmpty.type] = FakeRequest("GET", "/some/resource/path")
+    val app: Application = application().build()
+    implicit val appConfig: AppConfig = app.injector.instanceOf[AppConfig]
+
+    override def messagesApi: MessagesApi = app.injector.instanceOf[MessagesApi]
+    implicit val messages: Messages = messagesApi.preferred(request)
+
+    val view: Document = Jsoup.parse(
+      app.injector.instanceOf[error_template].apply(
+        pageTitle = messages.apply("cf.error.technicalDifficulties.title"),
+        heading = messages.apply("cf.error.technicalDifficulties.heading"),
+        details = Seq(messages.apply("cf.error.technicalDifficulties.message")): _*
+      ).body
+    )
+
+    val backLink = view.select(".govuk-back-link").first()
+    val expectedBackLinkPath = "/customs/payment-records/authorized-to-view"
+  }
+}

--- a/test/views/LayoutSpec.scala
+++ b/test/views/LayoutSpec.scala
@@ -84,9 +84,7 @@ class LayoutSpec extends SpecBase with MustMatchers {
       viewDoc.getElementsByClass("govuk-back-link").attr("href")
         .contains(backLinkUrl.get) mustBe true
     } else {
-      viewDoc.getElementsByClass("govuk-back-link").text() mustBe "Back"
-      viewDoc.getElementsByClass("govuk-back-link").attr("href")
-        .contains("#") mustBe true
+      viewDoc.getElementsByClass("govuk-back-link").size() mustBe 0
     }
   }
 


### PR DESCRIPTION
[Todo]
- Refactored backLink initialisation to only create a `BackLink` instance if `backLink` has a non-empty value, avoiding unnecessary empty href values.
- Added `BackLink` url to the error page
- Updated unit tests 