### PR TITLE
[MMCA-5408] - Filter 404 code for EORI history call and add warn level

### DIFF
--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -22,7 +22,7 @@ object AppDependencies {
 
   val compile: Seq[ModuleID] = Seq(
     "uk.gov.hmrc"       %% "bootstrap-frontend-play-30" % bootstrapVersion,
-    "uk.gov.hmrc"       %% "play-partials-play-30"      % "10.0.0",
+    "uk.gov.hmrc"       %% "play-partials-play-30"      % "10.1.0",
     "uk.gov.hmrc"       %% "play-frontend-hmrc-play-30" % "11.13.0",
     ws,
     "org.typelevel"     %% "cats-core"                  % "2.13.0",

--- a/test/services/DataStoreServiceSpec.scala
+++ b/test/services/DataStoreServiceSpec.scala
@@ -381,7 +381,7 @@ class DataStoreServiceSpec extends SpecBase with MustMatchers with WireMockSuppo
         verifyEndPointUrlHit(xiEoriInfoUrl)
       }
 
-      "return None when retunred xi Eori is empty" in new Setup {
+      "return None when returned xi Eori is empty" in new Setup {
         val xiEori: String = emptyString
 
         val xiAddress: XiEoriAddressInformation =
@@ -403,21 +403,10 @@ class DataStoreServiceSpec extends SpecBase with MustMatchers with WireMockSuppo
       }
 
       "return None when feature flag is false" in new Setup {
-        override val mockMetricsReporterService = mock[MetricsReporterService]
-        val mockAppConfig                       = mock[AppConfig]
+        override val mockMetricsReporterService: MetricsReporterService = mock[MetricsReporterService]
+        val mockAppConfig: AppConfig                                    = mock[AppConfig]
 
-        val xiEori         = "XI123456789"
-        val xiAddress      = XiEoriAddressInformation("Street1", None, Some("City"), Some("GB"), Some("Post Code"))
-        val xiEoriResponse = XiEoriInformationReponse(xiEori, "S", xiAddress)
-
-        wireMockServer.stubFor(
-          get(urlPathMatching(xiEoriInfoUrl))
-            .willReturn(
-              ok(Json.toJson(xiEoriResponse).toString)
-            )
-        )
-
-        override val app = application()
+        override val app: Application = application()
           .configure(config)
           .overrides(
             inject.bind[MetricsReporterService].toInstance(mockMetricsReporterService),
@@ -438,7 +427,7 @@ class DataStoreServiceSpec extends SpecBase with MustMatchers with WireMockSuppo
         val result: Option[String] = await(service.getXiEori)
 
         result mustBe empty
-        verifyEndPointUrlHit(xiEoriInfoUrl)
+        verifyEndPointUrlHit(xiEoriInfoUrl, 0)
       }
     }
   }

--- a/test/utils/WireMockSupportProvider.scala
+++ b/test/utils/WireMockSupportProvider.scala
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package utils
+
+import com.github.tomakehurst.wiremock.client.WireMock.{getRequestedFor, urlPathMatching}
+import org.scalatest.Suite
+import play.api.Configuration
+import uk.gov.hmrc.http.test.WireMockSupport
+
+trait WireMockSupportProvider extends WireMockSupport {
+
+  this: Suite =>
+
+  def config: Configuration
+
+  protected def verifyEndPointUrlHit(urlToVerify: String): Unit = wireMockServer.verify(
+    getRequestedFor(
+      urlPathMatching(urlToVerify)
+    )
+  )
+}

--- a/test/utils/WireMockSupportProvider.scala
+++ b/test/utils/WireMockSupportProvider.scala
@@ -27,7 +27,8 @@ trait WireMockSupportProvider extends WireMockSupport {
 
   def config: Configuration
 
-  protected def verifyEndPointUrlHit(urlToVerify: String): Unit = wireMockServer.verify(
+  protected def verifyEndPointUrlHit(urlToVerify: String, count: Int = 1): Unit = wireMockServer.verify(
+    count,
     getRequestedFor(
       urlPathMatching(urlToVerify)
     )


### PR DESCRIPTION
Description - Filter 404 response code (from customs data store) for EORI history API call

Below has been done as part of this PR

- [x] add WireMock support
- [x] update existing tests to use WireMock
- [x] add tests
- [x] add relevant code to filter 404
- [x]  library version upgrades to address PlatOps warnings