### PR TITLE
MMCA-5415: Making the ID paramiter on the topuplinks disapear if no id is provided

### DIFF
--- a/app/views/account_cards/duty_deferment_account_cards.scala.html
+++ b/app/views/account_cards/duty_deferment_account_cards.scala.html
@@ -104,21 +104,21 @@
                     @accountRow.contentRow.nonDirectDebitContent.map { nonDD =>
                         <span class="card-footer__links govuk-body">
                             @nonDD.viewStatements.map { viewStat =>
-                                    <a @if(viewStat.id != null && viewStat.id.nonEmpty){id="@viewStat.id"} class="@viewStat.classValue" href="@viewStat.href">
+                                    <a class="@viewStat.classValue" href="@viewStat.href">
                                         <span aria-hidden="true">@viewStat.displayValue</span>
                                         <span class="govuk-visually-hidden">@viewStat.hiddenMsg</span>
                                     </a>
                             }
 
                             @nonDD.paymentDetails.map { payment =>
-                                    <a @if(payment.id != null && payment.id.nonEmpty){id="@payment.id"} class="@payment.classValue" href="@payment.href">
+                                    <a class="@payment.classValue" href="@payment.href">
                                         <span aria-hidden="true">@payment.displayValue</span>
                                         <span class="govuk-visually-hidden">@payment.hiddenMsg</span>
                                     </a>
                             }
 
                             @nonDD.topUp.map { topUp =>
-                                    <a @if(topUp.id != null && topUp.id.nonEmpty){id="@topUp.id"} class="@topUp.classValue" href="@topUp.href">
+                                    <a class="@topUp.classValue" href="@topUp.href">
                                         <span aria-hidden="true">@topUp.displayValue</span>
                                         <span class="govuk-visually-hidden">@topUp.hiddenMsg</span>
                                     </a>

--- a/app/views/account_cards/duty_deferment_account_cards.scala.html
+++ b/app/views/account_cards/duty_deferment_account_cards.scala.html
@@ -104,21 +104,21 @@
                     @accountRow.contentRow.nonDirectDebitContent.map { nonDD =>
                         <span class="card-footer__links govuk-body">
                             @nonDD.viewStatements.map { viewStat =>
-                                    <a id="@viewStat.id" class="@viewStat.classValue" href="@viewStat.href">
+                                    <a @if(viewStat.id != null && viewStat.id.nonEmpty){id="@viewStat.id"} class="@viewStat.classValue" href="@viewStat.href">
                                         <span aria-hidden="true">@viewStat.displayValue</span>
                                         <span class="govuk-visually-hidden">@viewStat.hiddenMsg</span>
                                     </a>
                             }
 
                             @nonDD.paymentDetails.map { payment =>
-                                    <a id="@payment.id" class="@payment.classValue" href="@payment.href">
+                                    <a @if(payment.id != null && payment.id.nonEmpty){id="@payment.id"} class="@payment.classValue" href="@payment.href">
                                         <span aria-hidden="true">@payment.displayValue</span>
                                         <span class="govuk-visually-hidden">@payment.hiddenMsg</span>
                                     </a>
                             }
 
                             @nonDD.topUp.map { topUp =>
-                                    <a id="@topUp.id" class="@topUp.classValue" href="@topUp.href">
+                                    <a @if(topUp.id != null && topUp.id.nonEmpty){id="@topUp.id"} class="@topUp.classValue" href="@topUp.href">
                                         <span aria-hidden="true">@topUp.displayValue</span>
                                         <span class="govuk-visually-hidden">@topUp.hiddenMsg</span>
                                     </a>


### PR DESCRIPTION
Following the DAC retest for WCAG 2.1 we have had a few issues flagged as either partially fixed or not fixed. These issues need to be resolved before our upcoming WCAG 2.2 accessibility audit at the end of the month.


https://jira.tools.tax.service.gov.uk/secure/RapidBoard.jspa?rapidView=5059&projectKey=MMCA&view=detail&selectedIssue=MMCA-5415#:~:text=%5Bhttps%3A//github.com/hmrc/accessibility%2Daudits%2Dexternal/issues/5388%5D

This PR is to remove the IDS from the dom if there are no params providedx