### PR TITLE
MMCA-5459: Remove CHIEF related content under Duty Deferment heading on dashboard

### DIFF
--- a/app/views/account_cards/duty_deferment_account_cards.scala.html
+++ b/app/views/account_cards/duty_deferment_account_cards.scala.html
@@ -29,8 +29,6 @@
             @model.titleMsg
         </h2>
 
-        @model.inaccurateBalancesMsg
-
         @for(accountRow <- model.accountSectionRows) {
             <div class="custom-card duty-deferment-account govuk-!-margin-bottom-7 govuk-!-margin-top-2">
                 <div class="card-main">

--- a/test/viewmodels/DutyDefermentAccountsViewModelSpec.scala
+++ b/test/viewmodels/DutyDefermentAccountsViewModelSpec.scala
@@ -26,8 +26,7 @@ import play.api.Application
 import play.api.i18n.Messages
 import utils.SpecBase
 import views.html.account_cards.{
-  duty_deferment_account_direct_debit_setup, duty_deferment_balance_details, duty_deferment_balances,
-  duty_deferment_inaccurate_balances_message
+  duty_deferment_account_direct_debit_setup, duty_deferment_balance_details, duty_deferment_balances
 }
 import views.html.components.{account_status, hidden_status}
 import utils.MustMatchers
@@ -37,19 +36,6 @@ import java.time.LocalDateTime
 class DutyDefermentAccountsViewModelSpec extends SpecBase with MustMatchers {
 
   "View model" should {
-
-    "contain correct title and inaccurate balances msg" when {
-
-      "there is only one DD account" in new Setup {
-        ddAccountsViewModelWithSingleAccount.titleMsg mustBe msgs("cf.customs-financials-home.duty-deferment.title")
-        shouldContainInaccurateBalancesMsg(ddAccountsViewModelWithSingleAccount)
-      }
-
-      "there are more than one DD account" in new Setup {
-        ddAccViewModelWithMultipleAccounts().titleMsg mustBe msgs("cf.customs-financials-home.duty-deferment.title2")
-        shouldContainInaccurateBalancesMsg(ddAccViewModelWithMultipleAccounts())
-      }
-    }
 
     "contain correct account section rows" when {
 
@@ -68,14 +54,6 @@ class DutyDefermentAccountsViewModelSpec extends SpecBase with MustMatchers {
           Seq(expectedAccountSectionRow(finHomeModel4), expectedAccountSectionRow(finHomeModel4))
       }
     }
-  }
-
-  private def shouldContainInaccurateBalancesMsg(
-    viewModel: DutyDefermentAccountsViewModel
-  )(implicit msgs: Messages, appConfig: AppConfig): Assertion = {
-    val expectedBalanceMsg = new duty_deferment_inaccurate_balances_message().apply()
-
-    viewModel.inaccurateBalancesMsg mustBe expectedBalanceMsg
   }
 
   private def expectedAccountSectionRow(

--- a/test/views/HomeViewSpec.scala
+++ b/test/views/HomeViewSpec.scala
@@ -62,14 +62,6 @@ class HomeViewSpec extends SpecBase {
 
   "not display manage your account authorities link" when {
 
-    "display recruitment banner" when {
-      "display duty deferment inaccurate balance message" in new Setup {
-        running(app) {
-          page(modelWithAgentAccess, None).containsElementById("duty-deferment-balances-warning")
-        }
-      }
-    }
-
     "banner links" when {
 
       "display the message banner partial" in new Setup {

--- a/test/views/account_cards/DutyDefermentAccountCardsSpec.scala
+++ b/test/views/account_cards/DutyDefermentAccountCardsSpec.scala
@@ -46,9 +46,6 @@ class DutyDefermentAccountCardsSpec extends SpecBase with MustMatchers {
         viewDoc(model).getElementsByTag("h2").text() mustBe
           msgs("cf.customs-financials-home.duty-deferment.title")
 
-        viewDoc(model).getElementById("duty-deferment-balances-warning").text() mustBe
-          msgs("cf.duty-deferment.outOfDateBalance.chiefText")
-
         viewDoc(model).getElementsByTag("h3").text() mustBe
           s"${msgs("cf.account")} $dan1 ${msgs("cf.account.status.aria.AccountStatusClosed")}"
 
@@ -71,9 +68,6 @@ class DutyDefermentAccountCardsSpec extends SpecBase with MustMatchers {
 
         viewDoc(model).getElementsByTag("h2").text() mustBe
           msgs("cf.customs-financials-home.duty-deferment.title2")
-
-        viewDoc(model).getElementById("duty-deferment-balances-warning").text() mustBe
-          msgs("cf.duty-deferment.outOfDateBalance.chiefText")
       }
 
       "model has one DutyDefermentAccount for the eori, with AccountStatusSuspended and NI account" in new Setup {
@@ -82,9 +76,6 @@ class DutyDefermentAccountCardsSpec extends SpecBase with MustMatchers {
 
         viewDoc(model).getElementsByTag("h2").text() mustBe
           msgs("cf.customs-financials-home.duty-deferment.title2")
-
-        viewDoc(model).getElementById("duty-deferment-balances-warning").text() mustBe
-          msgs("cf.duty-deferment.outOfDateBalance.chiefText")
 
         viewDoc(model)
           .getElementsByTag("h3")


### PR DESCRIPTION
As confirmed with Mike Crowhurst, CHIEF is no longer included within the balances held for duty deferment accounts, so the reference to CHIEF under the Duty Deferment heading on the MIDVA dashboard should be removed. 

Further info in the design ticket MMCA-3641